### PR TITLE
fix: entity 기본 값 설정을 수정

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/entity/OAuth.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/entity/OAuth.java
@@ -1,8 +1,17 @@
 package kakaotech.bootcamp.respec.specranking.domain.auth.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.OAuthProvider;
 import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +31,7 @@ public class OAuth {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "provider_name", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'KAKAO'")
+    @Column(name = "provider_name", nullable = false, columnDefinition = "VARCHAR(50)")
     private OAuthProvider providerName;
 
     @Column(name = "provider_id", nullable = false, columnDefinition = "VARCHAR(255)")

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/education/entity/Education.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/education/entity/Education.java
@@ -32,11 +32,11 @@ public class Education {
     private Spec spec;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "institute", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'MIDDLE_SCHOOL'")
+    @Column(name = "institute", nullable = false, columnDefinition = "VARCHAR(50)")
     private Institute institute;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'ENROLLED'")
+    @Column(name = "status", nullable = false, columnDefinition = "VARCHAR(50)")
     private FinalStatus status;
 
     public Education(Spec spec, Institute institute, FinalStatus status) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/educationdetail/entity/EducationDetail.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/educationdetail/entity/EducationDetail.java
@@ -34,7 +34,7 @@ public class EducationDetail {
     private String schoolName;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'COMPLETION'")
+    @Column(nullable = false, columnDefinition = "VARCHAR(50)")
     private Degree degree;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(50)")
@@ -43,7 +43,7 @@ public class EducationDetail {
     @Column(nullable = false, columnDefinition = "DOUBLE")
     private Double gpa;
 
-    @Column(name = "max_gpa", nullable = false, columnDefinition = "DOUBLE DEFAULT 4.0")
+    @Column(name = "max_gpa", nullable = false, columnDefinition = "DOUBLE")
     private Double maxGpa;
 
     public EducationDetail(Education education, String schoolName, Degree degree,

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/entity/Notification.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/entity/Notification.java
@@ -1,8 +1,17 @@
 package kakaotech.bootcamp.respec.specranking.domain.notification.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.NotificationTargetType;
 import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +31,7 @@ public class Notification {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "target_name", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'CHATTING'")
+    @Column(name = "target_name", nullable = false, columnDefinition = "VARCHAR(50)")
     private NotificationTargetType targetName;
 
     @Column(name = "target_id", nullable = false, columnDefinition = "BIGINT UNSIGNED")

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/workexperience/entity/WorkExperience.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/workexperience/entity/WorkExperience.java
@@ -34,7 +34,7 @@ public class WorkExperience {
     private String companyName;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'INTERN'")
+    @Column(nullable = false, columnDefinition = "VARCHAR(50)")
     private Position position;
 
     @Column(name = "work_month", nullable = false, columnDefinition = "SMALLINT UNSIGNED")


### PR DESCRIPTION
엔티티에 기본 값이 있음으로써 혼동을 줄 수 있는 부분을 수정하였습니다.
예를 들어 직무에 INTERN이 기본 값이 었습니다.
기본 값을 두지 않고 필수적으로 입력할 수 있도록 하여 명확히 그 사람의 스펙임을 보장합니다.