### PR TITLE
feat: 스펙 create, put Active 여부에 따라 validation

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/repository/SpecRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/repository/SpecRepository.java
@@ -6,10 +6,9 @@ import kakaotech.bootcamp.respec.specranking.domain.spec.entity.Spec;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpecRepository extends JpaRepository<Spec, Long>, SpecRepositoryCustom {
-    Optional<Spec> findByUserId(Long userId);
-
     Long countByStatus(SpecStatus status);
-    
+
     Optional<Spec> findByUserIdAndStatus(Long userId, SpecStatus status);
 
+    Optional<Spec> findByIdAndStatus(Long id, SpecStatus status);
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecService.java
@@ -14,6 +14,7 @@ import kakaotech.bootcamp.respec.specranking.domain.common.type.Degree;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.FinalStatus;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Institute;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Position;
+import kakaotech.bootcamp.respec.specranking.domain.common.type.SpecStatus;
 import kakaotech.bootcamp.respec.specranking.domain.education.entity.Education;
 import kakaotech.bootcamp.respec.specranking.domain.education.repository.EducationRepository;
 import kakaotech.bootcamp.respec.specranking.domain.educationdetail.repository.EducationDetailRepository;
@@ -78,8 +79,8 @@ public class SpecService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다. ID: " + userId));
 
-        Spec spec = specRepository.findById(specId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스펙입니다. ID: " + specId));
+        Spec spec = specRepository.findByIdAndStatus(specId, SpecStatus.ACTIVE)
+                .orElseThrow(() -> new IllegalArgumentException("수정할 수 없는 스펙입니다. ID: " + specId));
 
         if (!spec.getUser().equals(user)) {
             throw new IllegalArgumentException("해당 스펙에 대한 수정 권한이 없습니다.");
@@ -103,8 +104,8 @@ public class SpecService {
     }
 
     private void validateMultipleSpec(Long userId) {
-        Optional<Spec> existingSpec = specRepository.findByUserId(userId);
-        if (existingSpec.isPresent()) {
+        Optional<Spec> existingActiveSpec = specRepository.findByUserIdAndStatus(userId, SpecStatus.ACTIVE);
+        if (existingActiveSpec.isPresent()) {
             throw new IllegalStateException("이미 등록된 스펙이 있습니다. 스펙을 수정하려면 수정 API를 사용해주세요.");
         }
     }


### PR DESCRIPTION
프론트에서 active가 아닌 스펙을 수정 요청 하는 경우가 있다.

이를 백엔드 단에서 막기 위해 해당 부분 validation 기능을 추가한다.

마찬가지로 create도 active 스펙이 없을 경우 create가 가능하도록 로직을 수정한다.