### PR TITLE
fix: 채팅방-유저 매핑 테이블 추가, 알림 테이블 target_id 제거

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/entity/ChatParticipation.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/entity/ChatParticipation.java
@@ -1,0 +1,40 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatparticipation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kakaotech.bootcamp.respec.specranking.domain.chatroom.entity.Chatroom;
+import kakaotech.bootcamp.respec.specranking.domain.common.BaseTimeEntity;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatParticipation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "BIGINT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id", nullable = false, columnDefinition = "BIGINT UNSIGNED")
+    private Chatroom chatroom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "BIGINT UNSIGNED")
+    private User user;
+
+    public ChatParticipation(Chatroom chatroom, User user) {
+        this.chatroom = chatroom;
+        this.user = user;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/repository/ChatParticipationRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/repository/ChatParticipationRepository.java
@@ -1,0 +1,7 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatparticipation.repository;
+
+import kakaotech.bootcamp.respec.specranking.domain.chatparticipation.entity.ChatParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long> {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/service/ChatParticipationService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/service/ChatParticipationService.java
@@ -1,0 +1,9 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatparticipation.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ChatParticipationService {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/controller/ChatroomController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/controller/ChatroomController.java
@@ -1,0 +1,9 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatroom.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chatrooms")
+public class ChatroomController {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/entity/Chatroom.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/entity/Chatroom.java
@@ -1,0 +1,22 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatroom.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import kakaotech.bootcamp.respec.specranking.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chatroom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "BIGINT UNSIGNED")
+    private Long id;
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/repository/ChatroomRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/repository/ChatroomRepository.java
@@ -1,0 +1,7 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatroom.repository;
+
+import kakaotech.bootcamp.respec.specranking.domain.chatroom.entity.Chatroom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/service/ChatroomService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatroom/service/ChatroomService.java
@@ -1,0 +1,9 @@
+package kakaotech.bootcamp.respec.specranking.domain.chatroom.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ChatroomService {
+}


### PR DESCRIPTION
## ☝️ 요약

채팅방-유저 매핑 테이블 추가, 알림 테이블 target_id 제거

## ✏️ 상세 내용

필드 중복 방지 하기 위한 채팅방-유저 매핑 테이블 추가
불필요한 레코드 첨가 방지를 위한 알림 테이블 target_id 필드 제거

## ✅ 체크리스트

- [x] 엔티티 수정
- [x] 그에 따른 controller, service, respository 제작

