### PR TITLE
fix: SecurityConfig 경로별 인가 설정 수정

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/config/SecurityConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -85,13 +86,37 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers(
-                                "/",
-                                "/api/auth/**",
-                                "/oauth2/**",
-                                "/login/oauth2/**", "/api/**")
-                        .permitAll()
-                        .anyRequest().authenticated());
+                        .requestMatchers("/", "/oauth2/**", "/login/oauth2/**").permitAll()
+
+                        .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/token/refresh").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/users/{userId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/specs").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/specs/{specId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/specs/{specId}/comments").permitAll()
+
+                        .requestMatchers("/ws/**").authenticated()
+
+                        .requestMatchers(HttpMethod.PATCH, "/api/users/me").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/specs").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/specs/{specId}").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/specs/{specId}/visibility").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/specs/{specId}/bookmarks").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/specs/{specId}/bookmarks/{bookmarkId}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/bookmarks").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/specs/{specId}/comments").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/specs/{specId}/comments/{commentId}").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/specs/{specId}/comments/{commentId}").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/specs/{specId}/comments/{commentId}/replies").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/notifications").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/notifications").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/chatrooms").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/chatrooms/{chatroomId}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/chatrooms/{chatroomId}/messages").authenticated()
+
+                        .anyRequest().authenticated()
+                );
 
         // 세션 설정 : stateless
         http


### PR DESCRIPTION
## ☝️ 요약
SecurityConfig 경로별 인가 설정 수정

<br/>

## ✏️ 상세 내용
- 경로별 인가 설정이 잘못되어 Postman 테스트 시 응답바디에 카카오 로그인 리디렉션 html 코드가 출력되는 문제가 지속적으로 발생함
- api 명세서에 따른 요청만 허용하도록 함
- 요청 중 인증이 필요한 요청은 `.authenticated()`로 설정함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] Reviewer를 지정했습니다.
- [x] Postman 테스트 관련 문제를 해결했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)
- permitAll, authenticated에 문제가 없는지 검토해주시면 좋겠습니다.

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)