### PR TITLE
feat: 스펙 공개여부 변경 기능 구현

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/controller/UserController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/controller/UserController.java
@@ -6,12 +6,10 @@ import jakarta.validation.Valid;
 import kakaotech.bootcamp.respec.specranking.domain.auth.dto.AuthenticatedUserDto;
 import kakaotech.bootcamp.respec.specranking.domain.auth.jwt.CookieUtils;
 import kakaotech.bootcamp.respec.specranking.domain.auth.jwt.JWTUtil;
-import kakaotech.bootcamp.respec.specranking.domain.user.dto.UserSignupRequestDto;
-import kakaotech.bootcamp.respec.specranking.domain.user.dto.UserResponseDto;
-import kakaotech.bootcamp.respec.specranking.domain.user.dto.UserUpdateRequest;
-import kakaotech.bootcamp.respec.specranking.domain.user.dto.UserUpdateResponse;
+import kakaotech.bootcamp.respec.specranking.domain.user.dto.*;
 import kakaotech.bootcamp.respec.specranking.domain.user.service.UserService;
 import kakaotech.bootcamp.respec.specranking.domain.user.util.DuplicateNicknameException;
+import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -158,6 +156,12 @@ public class UserController {
             @RequestPart(value = "profileImageUrl", required = false) MultipartFile profileImageUrl) {
 
         return userService.updateUser(request, profileImageUrl);
+    }
+
+    @PatchMapping("/me/visibility")
+    public SimpleResponseDto updateUserVisibility(@RequestBody @Valid UserVisibilityRequest request) {
+        userService.updateUserVisibility(request.getIsPublic());
+        return new SimpleResponseDto(true, "스펙 공개여부 변경 성공");
     }
 }
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/dto/UserVisibilityRequest.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/dto/UserVisibilityRequest.java
@@ -1,0 +1,15 @@
+package kakaotech.bootcamp.respec.specranking.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class UserVisibilityRequest {
+
+    @NotNull(message = "공개 여부는 필수입니다.")
+    private Boolean isPublic;
+
+    public UserVisibilityRequest(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/entity/User.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/entity/User.java
@@ -106,4 +106,8 @@ public class User extends BaseTimeEntity {
                 this.status
         );
     }
+
+    public void updateIsOpenSpec(Boolean isOpenSpec) {
+        this.isOpenSpec = isOpenSpec;
+    }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/service/UserService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/service/UserService.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
 import kakaotech.bootcamp.respec.specranking.domain.auth.entity.OAuth;
 import kakaotech.bootcamp.respec.specranking.domain.auth.repository.OAuthRepository;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.OAuthProvider;
@@ -173,6 +175,16 @@ public class UserService {
 
         User savedUser = userRepository.save(updatedUser);
         return UserUpdateResponse.success(savedUser);
+    }
+
+    public void updateUserVisibility(Boolean isPublic) {
+        Optional<Long> optUserId = UserUtils.getCurrentUserId();
+        Long userId = optUserId.orElseThrow(() -> new IllegalArgumentException("로그인이 필요한 서비스입니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + userId));
+
+        user.updateIsOpenSpec(isPublic);
     }
 
     // UserResponseDto 생성 메소드


### PR DESCRIPTION
## ☝️ 요약
스펙 공개여부 변경 기능 구현

<br/>

## ✏️ 상세 내용
- 마이페이지에서 토글 버튼을 클릭함에 따라 User 테이블의 is_open_spec 필드를 변경하는 기능
- `PUT /api/specs/{specId}/visibility` -> `PATCH /api/users/me/visibility`로 API 명세서를 수정함
- DTO 작성함 (UserVisibilityRequest)
- UserController, UserService 작성함
- User 엔티티에 관련 생성자 추가함
- Postman 테스트 완료

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로그인되지 않은 사용자의 접근에 대해 막아놨는지 확인했습니다.
- [x] 스펙 공개여부가 잘 변경되는지 확인했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)