### PR TITLE
feat: 대댓글 작성 기능 구현

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/controller/CommentController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package kakaotech.bootcamp.respec.specranking.domain.comment.controller;
 import jakarta.validation.Valid;
 import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentPostRequest;
 import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentPostResponse;
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.ReplyPostResponse;
 import kakaotech.bootcamp.respec.specranking.domain.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,5 +22,14 @@ public class CommentController {
             @PathVariable Long specId,
             @RequestBody @Valid CommentPostRequest request) {
         return commentService.createComment(specId, request);
+    }
+
+    @PostMapping("/{commentId}/replies")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReplyPostResponse createReply(
+            @PathVariable Long specId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid CommentPostRequest request) {
+        return commentService.createReply(specId, commentId, request);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/ReplyPostResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/ReplyPostResponse.java
@@ -1,0 +1,36 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.dto;
+
+import lombok.Data;
+
+@Data
+public class ReplyPostResponse {
+    private Boolean isSuccess;
+    private String message;
+    private ReplyData data;
+
+    @Data
+    public static class ReplyData {
+        private Long commentId;
+        private String nickname;
+        private String profileImageUrl;
+        private String content;
+        private Integer depth;
+        private Long parentCommentId;
+
+        public ReplyData(Long commentId, String nickname, String profileImageUrl,
+                           String content, Integer depth, Long parentCommentId) {
+            this.commentId = commentId;
+            this.nickname = nickname;
+            this.profileImageUrl = profileImageUrl;
+            this.content = content;
+            this.depth = depth;
+            this.parentCommentId = parentCommentId;
+        }
+    }
+
+    public ReplyPostResponse(Boolean isSuccess, String message, ReplyData data) {
+        this.isSuccess = isSuccess;
+        this.message = message;
+        this.data = data;
+    }
+}


### PR DESCRIPTION
## ☝️ 요약
대댓글 작성 기능 구현

<br/>

## ✏️ 상세 내용
- DTO 작성함 (CommentPostRequest 재활용, ReplyPostResponse 생성)
- CommentController, CommentService 작성함
- 댓글 작성의 응답 DTO와 차이점 : replyCount 없음
- parentCommentId의 로직

  > 댓글1 (depth 0, parentCommentId null)
  >> 대댓글1 (depth 1, parentCommentId 댓글1.id)
  >> 대댓글2 (depth 1, parentCommentId 댓글1.id)

- Postman 테스트 완료

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로그인하지 않은 사용자에 대한 예외 처리가 잘 되는지 확인했습니다.
- [x] 찾을 수 없는 스펙이나 부모 댓글에 대한 예외 처리가 잘 되는지 확인했습니다.
- [x] 부모 댓글이 specId에 속하지 않을 때에 대한 예외 처리가 잘 되는지 확인했습니다.
- [x]  commentId가 최상위 댓글이 아닌 경우에 대한 예외 처리가 잘 되는지 확인했습니다.
- [x]  대댓글 작성이 잘 되는지 확인했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)