### PR TITLE
fix: Comment 엔티티에 writer 필드 추가

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/entity/Comment.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/entity/Comment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kakaotech.bootcamp.respec.specranking.domain.common.BaseTimeEntity;
 import kakaotech.bootcamp.respec.specranking.domain.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,6 +40,10 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_comment_id", columnDefinition = "BIGINT UNSIGNED")
     private Comment parentComment;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", columnDefinition = "BIGINT UNSIGNED")
+    private User writer;
+
     @Column(nullable = false, columnDefinition = "VARCHAR(255)")
     private String content;
 
@@ -48,8 +53,9 @@ public class Comment extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TINYINT UNSIGNED DEFAULT 0")
     private Integer depth;
 
-    public Comment(Spec spec, Comment parentComment, String content, int bundle, int depth) {
+    public Comment(Spec spec, User writer, Comment parentComment, String content, int bundle, int depth) {
         this.spec = spec;
+        this.writer = writer;
         this.parentComment = parentComment;
         this.content = content;
         this.bundle = bundle;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/service/CommentService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/service/CommentService.java
@@ -39,7 +39,7 @@ public class CommentService {
         Integer maxBundle = commentRepository.findMaxBundleBySpecId(specId);
         int newBundle = (maxBundle == null) ? 1 : maxBundle + 1;
 
-        Comment comment = new Comment(spec, null, request.getContent(), newBundle, 0);
+        Comment comment = new Comment(spec, user, null, request.getContent(), newBundle, 0);
         Comment savedComment = commentRepository.save(comment);
 
         CommentPostResponse.CommentData commentData = new CommentPostResponse.CommentData(
@@ -76,7 +76,7 @@ public class CommentService {
             throw new IllegalArgumentException("대댓글에는 답글을 작성할 수 없습니다. 최상위 댓글에만 답글을 작성해주세요.");
         }
 
-        Comment reply = new Comment(spec, parentComment, request.getContent(), parentComment.getBundle(), 1);
+        Comment reply = new Comment(spec, user, parentComment, request.getContent(), parentComment.getBundle(), 1);
         Comment savedReply = commentRepository.save(reply);
 
         ReplyPostResponse.ReplyData replyData = new ReplyPostResponse.ReplyData(


### PR DESCRIPTION
## ☝️ 요약
Comment 엔티티에 writer 필드 추가

<br/>

## ✏️ 상세 내용
- Comment 엔티티에 User 연관관계 설정하는 것을 빠뜨림
- User 연관관계 설정하여 댓글 작성자 id까지 함께 기록할 수 있도록 수정함
- 엔티티에 필드를 추가함에 따라 생성자도 수정함
- 생성자 수정에 따라 Service단의 메소드에서도 파라미터를 수정함
- Postman 테스트 완료

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 기존에 구현한 댓글 작성, 대댓글 작성 기능이 잘 작동하는지 확인했습니다.
- [x] DB에 writer_id가 함께 저장되는 것을 확인했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)