### PR TITLE
feat: 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/controller/CommentController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentPostRespo
 import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentUpdateResponse;
 import kakaotech.bootcamp.respec.specranking.domain.comment.dto.ReplyPostResponse;
 import kakaotech.bootcamp.respec.specranking.domain.comment.service.CommentService;
+import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -40,5 +41,12 @@ public class CommentController {
             @PathVariable Long commentId,
             @RequestBody @Valid CommentRequest request) {
         return commentService.updateComment(specId, commentId, request);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public SimpleResponseDto deleteComment(
+            @PathVariable Long specId,
+            @PathVariable Long commentId) {
+        return commentService.deleteComment(specId, commentId);
     }
 }


### PR DESCRIPTION
## ☝️ 요약
댓글 삭제 기능 구현

<br/>

## ✏️ 상세 내용
- CommentController, CommentService 작성함
- Postman 테스트 완료
  - 댓글 삭제는 작성자 본인만 가능해야 함
  - 이미 삭제된 댓글을 다시 삭제하려는 시도는 막아야 함
  - 댓글 삭제 시 연관된 대댓글들은 삭제하지 않고 남겨둬야 함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로그인하지 않은 사용자에 대한 예외처리가 잘 되는지 확인했습니다.
- [x] 댓글 id에 대한 예외처리가 잘 되는지 확인했습니다.
- [x] 작성자 본인만 댓글을 삭제할 수 있는지 확인했습니다.
- [x] 이미 삭제된 댓글에 대한 예외처리가 잘 되는지 확인했습니다.
- [x] 댓글 삭제 시 대댓글은 삭제되지 않고 남아있는지 확인했습니다.
- [x] 댓글 삭제가 잘 되는지 확인했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)