### PR TITLE
feat: 댓글 및 대댓글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/controller/CommentController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/controller/CommentController.java
@@ -1,13 +1,13 @@
 package kakaotech.bootcamp.respec.specranking.domain.comment.controller;
 
 import jakarta.validation.Valid;
-import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentRequest;
-import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentPostResponse;
-import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentUpdateResponse;
-import kakaotech.bootcamp.respec.specranking.domain.comment.dto.ReplyPostResponse;
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.*;
+import kakaotech.bootcamp.respec.specranking.domain.comment.service.CommentQueryService;
 import kakaotech.bootcamp.respec.specranking.domain.comment.service.CommentService;
 import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentQueryService commentQueryService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -48,5 +49,12 @@ public class CommentController {
             @PathVariable Long specId,
             @PathVariable Long commentId) {
         return commentService.deleteComment(specId, commentId);
+    }
+
+    @GetMapping
+    public CommentListResponse getComments(
+            @PathVariable Long specId,
+            @PageableDefault(size = 5) Pageable pageable) {
+        return commentQueryService.getComments(specId, pageable);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/CommentListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/CommentListResponse.java
@@ -1,0 +1,98 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.dto;
+
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+public class CommentListResponse {
+    private Boolean isSuccess;
+    private String message;
+    private CommentListData data;
+
+    @Data
+    public static class CommentListData {
+        private List<CommentWithReplies> comments;
+        private PageInfo pageInfo;
+
+        public CommentListData(Page<CommentWithReplies> page) {
+            this.comments = page.getContent();
+            this.pageInfo = new PageInfo(page);
+        }
+    }
+
+    @Data
+    public static class CommentWithReplies {
+        private Long commentId;
+        private Long writerId;
+        private String content;
+        private String nickname;
+        private String profileImageUrl;
+        private String createdAt;
+        private String updatedAt;
+        private Integer replyCount;
+        private List<ReplyInfo> replies;
+
+        public CommentWithReplies(Long commentId, Long writerId, String content, String nickname,
+                                  String profileImageUrl, String createdAt, String updatedAt,
+                                  Integer replyCount, List<ReplyInfo> replies) {
+            this.commentId = commentId;
+            this.writerId = writerId;
+            this.content = content;
+            this.nickname = nickname;
+            this.profileImageUrl = profileImageUrl;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+            this.replyCount = replyCount;
+            this.replies = replies;
+        }
+    }
+
+    @Data
+    public static class ReplyInfo {
+        private Long replyId;
+        private Long writerId;
+        private String content;
+        private String nickname;
+        private String profileImageUrl;
+        private String createdAt;
+        private String updatedAt;
+
+        public ReplyInfo(Long replyId, Long writerId, String content, String nickname,
+                         String profileImageUrl, String createdAt, String updatedAt) {
+            this.replyId = replyId;
+            this.writerId = writerId;
+            this.content = content;
+            this.nickname = nickname;
+            this.profileImageUrl = profileImageUrl;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+        }
+    }
+
+    @Data
+    public static class PageInfo {
+        private Integer pageNumber;
+        private Integer pageSize;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean isFirst;
+        private Boolean isLast;
+
+        public PageInfo(Page<?> page) {
+            this.pageNumber = page.getNumber();
+            this.pageSize = page.getSize();
+            this.totalElements = page.getTotalElements();
+            this.totalPages = page.getTotalPages();
+            this.isFirst = page.isFirst();
+            this.isLast = page.isLast();
+        }
+    }
+
+    public CommentListResponse(Boolean isSuccess, String message, CommentListData data) {
+        this.isSuccess = isSuccess;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/CommentQueryDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/CommentQueryDto.java
@@ -1,0 +1,36 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CommentQueryDto {
+    private Long commentId;
+    private Long writerId;
+    private String content;
+    private String nickname;
+    private String profileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private Integer bundle;
+
+    public CommentQueryDto(Long commentId, Long writerId, String content, String nickname,
+                           String profileImageUrl, LocalDateTime createdAt, LocalDateTime updatedAt,
+                           LocalDateTime deletedAt, Integer bundle) {
+        this.commentId = commentId;
+        this.writerId = writerId;
+        this.content = content;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+        this.bundle = bundle;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/ReplyQueryDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/dto/ReplyQueryDto.java
@@ -1,0 +1,29 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReplyQueryDto {
+    private Long replyId;
+    private Long writerId;
+    private String content;
+    private String nickname;
+    private String profileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer bundle;
+
+    public ReplyQueryDto(Long replyId, Long writerId, String content, String nickname,
+                         String profileImageUrl, LocalDateTime createdAt, LocalDateTime updatedAt, Integer bundle) {
+        this.replyId = replyId;
+        this.writerId = writerId;
+        this.content = content;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.bundle = bundle;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CommentRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
     @Query("SELECT COUNT(c) FROM Comment c WHERE c.spec.id = :specId")
     Long countBySpecId(@Param("specId") Long specId);
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.repository;
+
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentRepositoryCustom {
+    Page<CommentListResponse.CommentWithReplies> findCommentsWithReplies(Long specId, Pageable pageable);
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,208 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentListResponse;
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentQueryDto;
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.ReplyQueryDto;
+import kakaotech.bootcamp.respec.specranking.domain.comment.entity.QComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static kakaotech.bootcamp.respec.specranking.domain.comment.entity.QComment.comment;
+
+@Repository
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CommentRepositoryImpl(EntityManager em) { this.queryFactory = new JPAQueryFactory(em); }
+
+    QComment subComment = new QComment("subComment");
+
+    @Override
+    public Page<CommentListResponse.CommentWithReplies> findCommentsWithReplies(Long specId, Pageable pageable) {
+        List<CommentQueryDto> parentComments = findParentComments(specId, pageable);
+        if (parentComments.isEmpty()) { return new PageImpl<>(List.of(), pageable, 0); }
+
+        List<Integer> bundles = extractBundles(parentComments);
+        List<ReplyQueryDto> replies = findRepliesBySpecIdAndBundles(specId, bundles);
+        Map<Integer, Long> replyCountMap = countRepliesBySpecIdAndBundles(specId, bundles);
+        Map<Integer, List<ReplyQueryDto>> repliesByBundle = groupRepliesByBundle(replies);
+
+        List<CommentListResponse.CommentWithReplies> result = buildCommentWithReplies(
+                parentComments, repliesByBundle, replyCountMap
+        );
+
+        Long totalElements = countTotalCommentsAndReplies(specId);
+        Long totalParentComments = countTotalParentComments(specId);
+
+        return new CustomPageImpl<>(result, pageable, totalParentComments, totalElements);
+    }
+
+    private List<CommentQueryDto> findParentComments(Long specId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(CommentQueryDto.class,
+                        comment.id,
+                        comment.writer.id,
+                        comment.content,
+                        comment.writer.nickname,
+                        comment.writer.userProfileUrl,
+                        comment.createdAt,
+                        comment.updatedAt,
+                        comment.deletedAt,
+                        comment.bundle))
+                .from(comment)
+                .where(comment.spec.id.eq(specId)
+                        .and(comment.depth.eq(0))
+                        .and(comment.deletedAt.isNull()
+                                .or(comment.deletedAt.isNotNull()
+                                        .and(JPAExpressions
+                                                .select(subComment.count())
+                                                .from(subComment)
+                                                .where(subComment.spec.id.eq(specId)
+                                                        .and(subComment.bundle.eq(comment.bundle))
+                                                        .and(subComment.depth.eq(1))
+                                                        .and(subComment.deletedAt.isNull()))
+                                                .gt(0L))
+
+                                )))
+                .orderBy(comment.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private List<Integer> extractBundles(List<CommentQueryDto> parentComments) {
+        return parentComments.stream().map(CommentQueryDto::getBundle).toList();
+    }
+
+    private List<ReplyQueryDto> findRepliesBySpecIdAndBundles(Long specId, List<Integer> bundles) {
+        return queryFactory
+                .select(Projections.constructor(ReplyQueryDto.class,
+                        comment.id,
+                        comment.writer.id,
+                        comment.content,
+                        comment.writer.nickname,
+                        comment.writer.userProfileUrl,
+                        comment.createdAt,
+                        comment.updatedAt,
+                        comment.bundle))
+                .from(comment)
+                .where(comment.spec.id.eq(specId)
+                        .and(comment.bundle.in(bundles))
+                        .and(comment.depth.eq(1))
+                        .and(comment.deletedAt.isNull()))
+                .orderBy(comment.createdAt.asc())
+                .fetch();
+    }
+
+    private Map<Integer, Long> countRepliesBySpecIdAndBundles(Long specId, List<Integer> bundles) {
+        return queryFactory
+                .select(comment.bundle, comment.count())
+                .from(comment)
+                .where(comment.spec.id.eq(specId)
+                        .and(comment.bundle.in(bundles))
+                        .and(comment.depth.eq(1))
+                        .and(comment.deletedAt.isNull()))
+                .groupBy(comment.bundle)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(comment.bundle),
+                        tuple -> {
+                            Long count = tuple.get(comment.count());
+                            return count != null ? count : 0L;
+                        }
+                ));
+    }
+
+    private Map<Integer, List<ReplyQueryDto>> groupRepliesByBundle(List<ReplyQueryDto> replies) {
+        return replies.stream().collect(Collectors.groupingBy(ReplyQueryDto::getBundle));
+    }
+
+    private List<CommentListResponse.CommentWithReplies> buildCommentWithReplies(
+            List<CommentQueryDto> parentComments,
+            Map<Integer, List<ReplyQueryDto>> repliesByBundle,
+            Map<Integer, Long> replyCountMap) {
+        return parentComments.stream()
+                .map(parentComment -> {
+                    List<ReplyQueryDto> childReplies = repliesByBundle.getOrDefault(parentComment.getBundle(), List.of());
+                    List<CommentListResponse.ReplyInfo> replyInfos = childReplies.stream().map(this::convertToReplyInfo).toList();
+
+                    Integer replyCount = replyCountMap.getOrDefault(parentComment.getBundle(), 0L).intValue();
+
+                    String maskedContent = parentComment.isDeleted() ? "삭제된 댓글입니다." : parentComment.getContent();
+                    String maskedNickname = parentComment.isDeleted() ? "삭제된 사용자" : parentComment.getNickname();
+                    String maskedProfileUrl = parentComment.isDeleted() ? null : parentComment.getProfileImageUrl();
+
+                    return new CommentListResponse.CommentWithReplies(
+                            parentComment.getCommentId(),
+                            parentComment.getWriterId(),
+                            maskedContent,
+                            maskedNickname,
+                            maskedProfileUrl,
+                            formatDateTime(parentComment.getCreatedAt()),
+                            formatDateTime(parentComment.getUpdatedAt()),
+                            replyCount,
+                            replyInfos
+                    );
+                })
+                .toList();
+    }
+
+    private CommentListResponse.ReplyInfo convertToReplyInfo(ReplyQueryDto dto) {
+        return new CommentListResponse.ReplyInfo(
+                dto.getReplyId(),
+                dto.getWriterId(),
+                dto.getContent(),
+                dto.getNickname(),
+                dto.getProfileImageUrl(),
+                formatDateTime(dto.getCreatedAt()),
+                formatDateTime(dto.getUpdatedAt())
+        );
+    }
+
+    private String formatDateTime(LocalDateTime dateTime) {
+        return dateTime != null ? dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) : null;
+    }
+
+    private Long countTotalCommentsAndReplies(Long specId) {
+        return queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.spec.id.eq(specId)
+                        .and(comment.deletedAt.isNull()))
+                .fetchOne();
+    }
+
+    private Long countTotalParentComments(Long specId) {
+        return queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.spec.id.eq(specId)
+                        .and(comment.depth.eq(0))
+                        .and(comment.deletedAt.isNull()
+                                .or(comment.deletedAt.isNotNull()
+                                        .and(JPAExpressions
+                                                .select(subComment.count())
+                                                .from(subComment)
+                                                .where(subComment.spec.id.eq(specId)
+                                                        .and(subComment.bundle.eq(comment.bundle))
+                                                        .and(subComment.depth.eq(1))
+                                                        .and(subComment.deletedAt.isNull()))
+                                                .gt(0L))
+                                )))
+                .fetchOne();
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CustomPageImpl.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/repository/CustomPageImpl.java
@@ -1,0 +1,19 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.repository;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class CustomPageImpl<T> extends PageImpl<T> {
+
+    private final Long customTotalElements;
+
+    public CustomPageImpl(List<T> content, Pageable pageable, Long totalForPagination, Long customTotalElements) {
+        super(content, pageable, totalForPagination);
+        this.customTotalElements = customTotalElements;
+    }
+
+    @Override
+    public long getTotalElements() { return customTotalElements; }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/comment/service/CommentQueryService.java
@@ -1,0 +1,31 @@
+package kakaotech.bootcamp.respec.specranking.domain.comment.service;
+
+import kakaotech.bootcamp.respec.specranking.domain.comment.dto.CommentListResponse;
+import kakaotech.bootcamp.respec.specranking.domain.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.common.type.SpecStatus;
+import kakaotech.bootcamp.respec.specranking.domain.spec.repository.SpecRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentQueryService {
+
+    private final CommentRepository commentRepository;
+    private final SpecRepository specRepository;
+
+    public CommentListResponse getComments(Long specId, Pageable pageable) {
+        specRepository.findByIdAndStatus(specId, SpecStatus.ACTIVE)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 비활성화된 스펙입니다. ID: " + specId));
+
+        Page<CommentListResponse.CommentWithReplies> commentsPage = commentRepository.findCommentsWithReplies(specId, pageable);
+
+        CommentListResponse.CommentListData data = new CommentListResponse.CommentListData(commentsPage);
+
+        return new CommentListResponse(true, "댓글 및 대댓글 목록 조회 성공", data);
+    }
+}


### PR DESCRIPTION
## ☝️ 요약
댓글 및 대댓글 목록 조회 기능 구현

<br/>

## ✏️ 상세 내용
- CommentController : `GET /api/specs/{specId}/comments?page={page}&size={size}` 매핑
- CommentListResponse : 응답바디 DTO (isSuccess / message / data.comments / data.pageInfo)
- CommentQueryService : 본 기능에 대한 비즈니스 로직 작성
- CommentRepositoryCustom : Repository 인터페이스 생성
- CustomPageImpl : PageImpl을 상속받아 페이지네이션 커스텀함
- CommentQueryDto, ReplyQueryDto : QueryDSL에서 활용할 DTO 클래스 생성. 불필요한 필드까지 가져오지 않기 위함
- CommentRepositoryImpl : QueryDSL 작성

- 오프셋 기반 페이지네이션 구현
  - 댓글은 최신순 정렬, 대댓글은 오래된순 정렬 
  - 삭제된 최상위 댓글은 연관된 대댓글이 1개 이상일 때만 조회에 포함
  - 삭제된 대댓글은 전부 조회에서 제외

- CommentRepositoryImpl 로직
  - 페이지네이션 적용해 최상위 댓글 전부 조회
  - 해당 페이지의 댓글들의 대댓글 전부 조회
  - 각 댓글의 대댓글 개수 조회
  - 대댓글을 부모 댓글별로 그룹화
  - 최종 응답 데이터 조합
  - 전체 댓글 개수 조회 (페이지네이션용)
  - 전체 댓글+대댓글 개수 조회 (응답바디에 포함할 용도)

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] Postman 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)