### PR TITLE
fix: 즐겨찾기 해제 및 즐겨찾기 버튼 표시 안되는 문제 수정

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/controller/BookmarkController.java
@@ -31,9 +31,9 @@ public class BookmarkController {
         return new BookmarkCreateResponse(true, "즐겨찾기 등록 성공", bookmarkId);
     }
 
-    @DeleteMapping("/{bookmarkId}")
-    public SimpleResponseDto deleteBookmark(@PathVariable Long bookmarkId) {
-        bookmarkService.deleteBookmark(bookmarkId);
+    @DeleteMapping("/specs/{specId}")
+    public SimpleResponseDto deleteBookmark(@PathVariable Long specId) {
+        bookmarkService.deleteBookmark(specId);
         return new SimpleResponseDto(true, "즐겨찾기 해제 성공");
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/dto/BookmarkListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/dto/BookmarkListResponse.java
@@ -39,6 +39,7 @@ public class BookmarkListResponse {
     @Data
     public static class SpecInfo {
         private Long id;
+        private Long userId;
         private String nickname;
         private String profileImageUrl;
         private Double score;
@@ -51,10 +52,11 @@ public class BookmarkListResponse {
         private Long commentsCount;
         private Long bookmarksCount;
 
-        public SpecInfo(Long id, String nickname, String profileImageUrl, Double score,
+        public SpecInfo(Long id, Long userId, String nickname, String profileImageUrl, Double score,
                         Long totalRank, Long totalUserCount, Long jobFieldRank, Long jobFieldUserCount,
                         JobField jobField, Boolean isBookmarked, Long commentsCount, Long bookmarksCount) {
             this.id = id;
+            this.userId = userId;
             this.nickname = nickname;
             this.profileImageUrl = profileImageUrl;
             this.score = score;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/repository/BookmarkRepository.java
@@ -1,6 +1,8 @@
 package kakaotech.bootcamp.respec.specranking.domain.bookmark.repository;
 
 import java.util.List;
+import java.util.Optional;
+
 import kakaotech.bootcamp.respec.specranking.domain.bookmark.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +17,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Long countBySpecId(@Param("specId") Long specId);
 
     boolean existsBySpecIdAndUserId(Long specId, Long userId);
+
+    Optional<Bookmark> findBySpecIdAndUserId(Long specId, Long userId);
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/service/BookmarkQueryService.java
@@ -64,6 +64,7 @@ public class BookmarkQueryService {
 
             BookmarkListResponse.SpecInfo specInfo = new BookmarkListResponse.SpecInfo(
                     spec.getId(),
+                    specUser.getId(),
                     specUser.getNickname(),
                     specUser.getUserProfileUrl(),
                     score,

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/bookmark/service/BookmarkService.java
@@ -41,13 +41,15 @@ public class BookmarkService {
         return savedBookmark.getId();
     }
 
-    public void deleteBookmark(Long bookmarkId) {
+    public void deleteBookmark(Long specId) {
         Optional<Long> optUserId = UserUtils.getCurrentUserId();
         Long userId = optUserId.orElseThrow(() -> new IllegalArgumentException("로그인이 필요한 서비스입니다."));
         userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + userId));
 
-        Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 즐겨찾기를 찾을 수 없습니다. ID: " + bookmarkId));
+        specRepository.findById(specId).orElseThrow(() -> new IllegalArgumentException("스펙을 찾을 수 없습니다. ID: " + specId));
+
+        Bookmark bookmark = bookmarkRepository.findBySpecIdAndUserId(specId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 즐겨찾기를 찾을 수 없습니다. 이미 삭제되었거나 존재하지 않습니다."));
 
         bookmarkRepository.delete(bookmark);
     }


### PR DESCRIPTION
## ☝️ 요약
즐겨찾기 해제 및 즐겨찾기 버튼 표시 안되는 문제 수정

<br/>

## ✏️ 상세 내용
- 즐겨찾기 해제 오류
    - RankingItem에 즐겨찾기 버튼이 포함되어 있다. 그런데 랭킹 조회 시 isBookmarked만 반환하고 bookmarkId를 반환하지 않아 `DELETE /api/bookmarks/{bookmarkId}` 호출 시 bookmarkId가 null인 상황이 발생한다.
    - bookmarkId를 응답바디에서 반환하면 새로고침하지 않으면 즐겨찾기 등록/해제를 반복적으로 할 수 없다는 문제가 있다.
    - DELETE도 POST처럼 `/api/bookmarks/specs/{specId}`로 변경하여 문제를 해결했다.
- 즐겨찾기 페이지에서 즐겨찾기 버튼 안 나타나는 문제
  - 다른 페이지처럼 RankingItem 컴포넌트를 활용하는데 즐겨찾기 페이지에서만 즐겨찾기 버튼이 표시되지 않는다.
  - userId를 응답바디에서 반환하지 않아 사용자를 인식할 수 없어 발생하는 문제였다.
  - BE BookmarkListResponse에 userId 추가하여 문제를 해결했다.

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)