### PR TITLE
fix: 사용자 스펙 공개여부와 타인의 스펙 상세정보를 조회할 수 없는 문제 해결 

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecDetailQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecDetailQueryService.java
@@ -52,10 +52,8 @@ public class SpecDetailQueryService {
                 .orElseThrow(() -> new IllegalArgumentException("Spec not found"));
 
         Optional<Long> userIdOpt = UserUtils.getCurrentUserId();
-        Long loginUserId = userIdOpt.orElseThrow(() -> new IllegalArgumentException("로그인이 필요한 서비스입니다."));
-
-        if (!spec.getUser().getId().equals(loginUserId)) {
-            throw new IllegalArgumentException("자신의 스펙 정보만 조회 가능합니다.");
+        if (!userIdOpt.isPresent()) {
+            throw new IllegalArgumentException("로그인이 필요한 서비스입니다.");
         }
 
         SpecDetailResponse.SpecDetailData response = new SpecDetailResponse.SpecDetailData();

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/controller/UserController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/controller/UserController.java
@@ -88,42 +88,9 @@ public class UserController {
         }
     }
 
-    // 사용자 기본정보 조회
     @GetMapping("/{userId}")
-    public ResponseEntity<?> getUserInfo(@PathVariable String userId) {
-        Long id;
-
-        // me이면 현재 로그인한 사용자 id 추출, 숫자인 경우 타인 id 조회
-        if ("me".equals(userId)) {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-            if (authentication == null || !(authentication.getPrincipal() instanceof AuthenticatedUserDto userDto)) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
-                        "isSuccess", false,
-                        "message", "로그인 정보가 없습니다."
-                ));
-            }
-
-            id = userDto.getId();
-        } else {
-            try {
-                id = Long.parseLong(userId);
-            } catch (NumberFormatException e) {
-                return ResponseEntity.badRequest().body(Map.of(
-                        "isSuccess", false,
-                        "message", "유효하지 않은 userId입니다."
-                ));
-            }
-        }
-
-        // 사용자 정보 조회
-        Map<String, Object> userData = userService.getUserInfo(id);
-
-        return ResponseEntity.ok(Map.of(
-                "isSuccess", true,
-                "message", "정보 조회 성공",
-                "data", Map.of("user", userData)
-        ));
+    public UserDetailResponse getUserInfo(@PathVariable Long userId) {
+        return userService.getUserInfo(userId);
     }
 
     // 회원탈퇴

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/dto/UserDetailResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/user/dto/UserDetailResponse.java
@@ -1,0 +1,85 @@
+package kakaotech.bootcamp.respec.specranking.domain.user.dto;
+
+import kakaotech.bootcamp.respec.specranking.domain.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserDetailResponse {
+    private Boolean isSuccess;
+    private String message;
+    private UserInfoData data;
+
+    @Data
+    public static class UserInfoData {
+        private UserDetail user;
+
+        public UserInfoData(UserDetail user) {
+            this.user = user;
+        }
+    }
+
+    @Data
+    public static class UserDetail {
+        private Long id;
+        private String nickname;
+        private String profileImageUrl;
+        private LocalDateTime createdAt;
+        private String jobField;
+        private Boolean isOpenSpec;
+        private SpecInfo spec;
+
+        public UserDetail(Long id, String nickname, String profileImageUrl, LocalDateTime createdAt,
+                          String jobField, Boolean isOpenSpec, SpecInfo spec) {
+            this.id = id;
+            this.nickname = nickname;
+            this.profileImageUrl = profileImageUrl;
+            this.createdAt = createdAt;
+            this.jobField = jobField;
+            this.isOpenSpec = isOpenSpec;
+            this.spec = spec;
+        }
+    }
+
+    @Data
+    public static class SpecInfo {
+        private Boolean hasActiveSpec;
+        private Long activeSpec;
+
+        public SpecInfo(Boolean hasActiveSpec, Long activeSpec) {
+            this.hasActiveSpec = hasActiveSpec;
+            this.activeSpec = activeSpec;
+        }
+    }
+
+    public UserDetailResponse(Boolean isSuccess, String message, UserInfoData data) {
+        this.isSuccess = isSuccess;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static UserDetailResponse success(UserDetail user) {
+        UserInfoData data = new UserInfoData(user);
+        return new UserDetailResponse(true, "사용자 정보 조회 성공", data);
+    }
+
+    public static UserDetail createUserDetail(User user, Spec activeSpec) {
+        String jobField = activeSpec != null ? activeSpec.getJobField().getValue() : null;
+        SpecInfo specInfo = new SpecInfo(
+                activeSpec != null,
+                activeSpec != null ? activeSpec.getId() : null
+        );
+
+        return new UserDetail(
+                user.getId(),
+                user.getNickname(),
+                user.getUserProfileUrl(),
+                user.getCreatedAt(),
+                jobField,
+                user.getIsOpenSpec(),
+                specInfo
+        );
+    }
+}


### PR DESCRIPTION
## ☝️ 요약
사용자 스펙 공개여부와 타인의 스펙 상세정보를 조회할 수 없는 문제 해결 

<br/>

## ✏️ 상세 내용
- 사용자 기본정보 조회 시 스펙 공개여부는 알 수 없는 문제 발생
  - 해당 계정의 소셜페이지 접근 가능여부 판단 불가
  - 사용자 기본정보 조회 dto 생성 (리팩토링) + isOpenSpec 필드 추가
- 타인의 스펙 상세정보를 조회할 수 없는 문제 발생
  - 타인의 소셜페이지 접근 시도 시 '자신의 스펙만 조회할 수 있습니다.' 에러 메시지 반환
  - 타인의 소셜페이지 접근 불가
  - 자신의 스펙이 아니어도 로그인한 사용자이면 모두 스펙 상세정보를 조회할 수 있도록 수정함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)