### PR TITLE
fix: 쿠키 httponly false 설정 명시

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/jwt/CookieUtils.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/jwt/CookieUtils.java
@@ -3,43 +3,70 @@ package kakaotech.bootcamp.respec.specranking.domain.auth.jwt;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
+@Slf4j
 public class CookieUtils {
 
-    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    private static final class CookieConfig {
+        static final boolean IS_SECURE = true;
+        static final boolean IS_HTTP_ONLY = false;
+        static final String DEFAULT_PATH = "/";
+        static final String SAME_SITE_CROSS_DOMAIN = "None";
+        static final String DOMAIN = "dev.specranking.net";
+    }
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String cookieName) {
         if (request.getCookies() == null) return Optional.empty();
         return Arrays.stream(request.getCookies())
-                .filter(cookie -> name.equals(cookie.getName()))
+                .filter(cookie -> cookieName.equals(cookie.getName()))
                 .findFirst();
     }
 
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         try {
-            String encodedValue = URLEncoder.encode(value, StandardCharsets.UTF_8);
+            ResponseCookie cookie = ResponseCookie.from(name, value)
+                            .domain(CookieConfig.DOMAIN)
+                            .path(CookieConfig.DEFAULT_PATH)
+                            .maxAge(maxAge)
+                            .secure(CookieConfig.IS_SECURE)
+                            .httpOnly(CookieConfig.IS_HTTP_ONLY)
+                            .sameSite(CookieConfig.SAME_SITE_CROSS_DOMAIN)
+                            .build();
 
-            // Secure, HttpOnly, SameSite=None, Domain 명시
-            String cookieString = String.format(
-                    "%s=%s; Max-Age=%d; Path=/; Domain=dev.specranking.net; Secure; SameSite=None",
-                    name, encodedValue, maxAge
-            );
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+            log.info("쿠키 설정 완료 - Name: {}, Value 길이: {}, MaxAge: {}초", name, value.length(), maxAge);
+            log.debug("쿠키 상세: {}", cookie);
 
-            response.addHeader("Set-Cookie", cookieString);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to encode cookie", e);
+            log.error("쿠키 설정 실패 - Name: {}, Value 길이: {}", name, value.length(), e);
+            throw new RuntimeException("Failed to set cookie", e);
         }
     }
 
     public static void deleteCookie(HttpServletResponse response, String name) {
-        // 삭제 시에도 동일한 도메인, Secure, SameSite 설정 필요
-        String cookieString = String.format(
-                "%s=; Max-Age=0; Path=/; Domain=dev.specranking.net; Secure; SameSite=None",
-                name
-        );
-        response.addHeader("Set-Cookie", cookieString);
+        try {
+            ResponseCookie deleteCookie = ResponseCookie.from(name, "")
+                    .domain(CookieConfig.DOMAIN)
+                    .path(CookieConfig.DEFAULT_PATH)
+                    .maxAge(0)
+                    .secure(CookieConfig.IS_SECURE)
+                    .httpOnly(CookieConfig.IS_HTTP_ONLY)
+                    .sameSite(CookieConfig.SAME_SITE_CROSS_DOMAIN)
+                    .build();
+
+            response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+            log.info("쿠키 삭제 완료 - Name: {}", name);
+            log.debug("삭제 쿠키 상세: {}", deleteCookie);
+
+        } catch (Exception e) {
+            log.error("쿠키 삭제 실패 - Name: {}", name, e);
+            throw new RuntimeException("Failed to delete cookie", e);
+        }
     }
 }


### PR DESCRIPTION
## ☝️ 요약
쿠키 httponly false 설정 명시

<br/>

## ✏️ 상세 내용
- 배포 환경에서 로그인 안 되는 문제로 CookieUtils 코드 수정함
- PC 버전에서는 로그인되지만 모바일에서는 여전히 로그인되지 않음
- CookieUtils 코드 리팩토링 및 httponly false 설정 명시함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
- 🚨 로컬 테스트 시 수정해야 하는 부분
  - `IS_SECURE = false;` 로 수정
  - `SAME_SITE_CROSS_DOMAIN = "Lax";` 로 수정
  - `DOMAIN = "localhost"';` 로 수정