### PR TITLE
fix: 도메인명 수정, isLocal 여부에 따른 변수 설정 추가

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/jwt/CookieUtils.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/jwt/CookieUtils.java
@@ -14,11 +14,13 @@ import java.util.Optional;
 public class CookieUtils {
 
     private static final class CookieConfig {
-        static final boolean IS_SECURE = true;
+        static final boolean IS_LOCAL = false;
+
+        static final boolean IS_SECURE = !IS_LOCAL;
         static final boolean IS_HTTP_ONLY = false;
         static final String DEFAULT_PATH = "/";
-        static final String SAME_SITE_CROSS_DOMAIN = "None";
-        static final String DOMAIN = "dev.specranking.net";
+        static final String SAME_SITE_CROSS_DOMAIN = IS_LOCAL ? "Lax" : "None";
+        static final String DOMAIN = IS_LOCAL ? "localhost" : ".dev.specranking.net";
     }
 
     public static Optional<Cookie> getCookie(HttpServletRequest request, String cookieName) {


### PR DESCRIPTION
## ☝️ 요약
도메인명 수정, isLocal 여부에 따른 변수 설정 추가

<br/>

## ✏️ 상세 내용
- CookieUtils 도메인명 수정 : `dev.specranking.net` -> `.dev.specranking.net`
- CookieUtils에서 개발/운영 환경에 따른 변수 설정 추가 -> `IS_LOCAL` 변수만 true/false 변경해서 사용하면 됨

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)