### PR TITLE
fix: 쿠키 도메인을 .specranking.net으로 변경

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/jwt/CookieUtils.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/jwt/CookieUtils.java
@@ -20,7 +20,7 @@ public class CookieUtils {
         static final boolean IS_HTTP_ONLY = false;
         static final String DEFAULT_PATH = "/";
         static final String SAME_SITE_CROSS_DOMAIN = IS_LOCAL ? "Lax" : "None";
-        static final String DOMAIN = IS_LOCAL ? "localhost" : ".dev.specranking.net";
+        static final String DOMAIN = IS_LOCAL ? "localhost" : ".specranking.net";
     }
 
     public static Optional<Cookie> getCookie(HttpServletRequest request, String cookieName) {


### PR DESCRIPTION
## ☝️ 요약
쿠키 도메인을 .specranking.net으로 변경

<br/>

## ✏️ 상세 내용
- 프론트엔드 도메인: dev.specranking.net / 백엔드 도메인: api.dev.specranking.net
- 서브 도메인 접근이 막혀서 백엔드에서 받은 쿠키가 제대로 인식되지 않는 것으로 예상됨
- 두 도메인에 대한 접근을 모두 허용하도록 도메인명 수정함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)