### PR TITLE
refactor: dto 모두 record로 변경

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/aiserver/MockAiServer.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/aiserver/MockAiServer.java
@@ -35,7 +35,7 @@ public class MockAiServer implements AiServer {
     private AiPostSpecResponse createMockAiResponse(AiPostSpecRequest aiPostSpecRequest) {
         AiPostSpecResponse response = new AiPostSpecResponse();
 
-        response.setNickname(aiPostSpecRequest.getNickname());
+        response.setNickname(aiPostSpecRequest.nickname());
         response.setEducationScore(generateRandomScore());
         response.setWorkExperienceScore(generateRandomScore());
         response.setCertificationScore(generateRandomScore());

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/mapping/AiDtoMapping.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/mapping/AiDtoMapping.java
@@ -21,143 +21,130 @@ import kakaotech.bootcamp.respec.specranking.domain.spec.dto.request.PostSpecReq
 public class AiDtoMapping {
 
     public static AiPostSpecRequest convertToSpecAnalysisRequest(PostSpecRequest request, String userNickname) {
-        AiPostSpecRequest aiRequest = new AiPostSpecRequest();
-
-        aiRequest.setNickname(userNickname);
-        mappingFinalEducation(request, aiRequest);
-        aiRequest.setJobField(request.getJobField());
-        mappingEducationDetails(request, aiRequest);
-        mappingWorkExperiences(request, aiRequest);
-        mappingCertifications(request, aiRequest);
-        mappingLanguageSkills(request, aiRequest);
-        mappingActivities(request, aiRequest);
+        AiPostSpecRequest aiRequest = new AiPostSpecRequest(userNickname,
+                request.finalEducation().institute(), request.finalEducation().status(),
+                request.jobField(),
+                mappingEducationDetails(request),
+                mappingWorkExperiences(request),
+                mappingCertifications(request),
+                mappingLanguageSkills(request),
+                mappingActivities(request)
+        );
 
         return aiRequest;
     }
 
-    private static void mappingFinalEducation(PostSpecRequest request, AiPostSpecRequest aiRequest) {
-        aiRequest.setInstitute(request.getFinalEducation().getInstitute());
-        aiRequest.setFinalStatus(request.getFinalEducation().getStatus());
-    }
-
-    private static void mappingEducationDetails(PostSpecRequest request, AiPostSpecRequest aiRequest) {
-        List<EducationDetail> universities = request.getEducationDetails().stream()
+    private static List<EducationDetail> mappingEducationDetails(PostSpecRequest request) {
+        List<EducationDetail> universities = request.educationDetails().stream()
                 .map(edu -> {
-                    EducationDetail educationDetail = new EducationDetail();
-                    educationDetail.setSchoolName(edu.getSchoolName());
-                    educationDetail.setDegree(edu.getDegree());
-                    educationDetail.setMajor(edu.getMajor());
-                    educationDetail.setGpa(edu.getGpa());
-                    educationDetail.setMaxGpa(edu.getMaxGpa());
+                    EducationDetail educationDetail = new EducationDetail(
+                            edu.schoolName(),
+                            edu.degree(),
+                            edu.major(),
+                            edu.gpa(),
+                            edu.maxGpa()
+                    );
                     return educationDetail;
                 })
                 .collect(Collectors.toList());
-        aiRequest.setEducationDetails(universities);
+
+        return universities;
     }
 
-    private static void mappingWorkExperiences(PostSpecRequest request, AiPostSpecRequest aiRequest) {
-        List<WorkExperience> workExperiences = request.getWorkExperiences().stream()
+    private static List<WorkExperience> mappingWorkExperiences(PostSpecRequest request) {
+        List<WorkExperience> workExperiences = request.workExperiences().stream()
                 .map(work -> {
-                    WorkExperience workExperience = new WorkExperience();
-                    workExperience.setCompanyName(work.getCompanyName());
-                    workExperience.setPosition(work.getPosition());
-                    workExperience.setPeriod(work.getPeriod());
-                    return workExperience;
+                    return new WorkExperience(work.companyName(), work.position(), work.period());
                 })
                 .collect(Collectors.toList());
-        aiRequest.setWorkExperiences(workExperiences);
+        return workExperiences;
     }
 
-    private static void mappingCertifications(PostSpecRequest request, AiPostSpecRequest aiRequest) {
-        List<String> certificates = request.getCertifications().stream()
-                .map(cert -> cert.getName())
+    private static List<String> mappingCertifications(PostSpecRequest request) {
+        List<String> certificates = request.certifications().stream()
+                .map(cert -> cert.name())
                 .collect(Collectors.toList());
-        aiRequest.setCertificates(certificates);
+        return certificates;
     }
 
-    private static void mappingLanguageSkills(PostSpecRequest request, AiPostSpecRequest aiRequest) {
-        List<LanguageSkill> languageSkills = request.getLanguageSkills().stream()
+    private static List<LanguageSkill> mappingLanguageSkills(PostSpecRequest request) {
+        List<LanguageSkill> languageSkills = request.languageSkills().stream()
                 .map(lang -> {
-                    LanguageSkill languageSkill = new LanguageSkill();
-                    languageSkill.setLanguageTest(lang.getLanguageTest());
-                    languageSkill.setScore(lang.getScore());
-                    return languageSkill;
+                    return new LanguageSkill(lang.languageTest(), lang.score());
                 })
                 .collect(Collectors.toList());
-        aiRequest.setLanguageSkills(languageSkills);
+        return languageSkills;
     }
 
-    private static void mappingActivities(PostSpecRequest request, AiPostSpecRequest aiRequest) {
-        List<AiPostSpecRequest.Activity> activities = request.getActivities().stream()
+    private static List<AiPostSpecRequest.Activity> mappingActivities(PostSpecRequest request) {
+        List<AiPostSpecRequest.Activity> activities = request.activities().stream()
                 .map(act -> {
-                    AiPostSpecRequest.Activity activity = new AiPostSpecRequest.Activity();
-                    activity.setName(act.getName());
-                    activity.setRole(act.getRole());
-                    activity.setAward(act.getAward());
-                    return activity;
+                    return new AiPostSpecRequest.Activity(
+                            act.name(), act.role(), act.award()
+                    );
                 })
                 .collect(Collectors.toList());
-        aiRequest.setActivities(activities);
+        return activities;
     }
 
     public static WebPostResumeResponse.ResumeAnalysisResult convertToResumeAnalysisResponse(
             AiPostResumeResponse response) {
 
-        Institute institute = safeConvertToEnum(response.getInstitute(), Institute.class, Institute.UNIVERSITY);
-        FinalStatus finalStatus = safeConvertToEnum(response.getFinalStatus(), FinalStatus.class,
+        Institute institute = safeConvertToEnum(response.institute(), Institute.class, Institute.UNIVERSITY);
+        FinalStatus finalStatus = safeConvertToEnum(response.finalStatus(), FinalStatus.class,
                 FinalStatus.GRADUATED);
-        JobField jobField = safeConvertToEnum(response.getJobField(), JobField.class, JobField.INTERNET_IT);
+        JobField jobField = safeConvertToEnum(response.jobField(), JobField.class, JobField.INTERNET_IT);
 
         WebPostResumeResponse.FinalEducation finalEducation =
                 new WebPostResumeResponse.FinalEducation(institute, finalStatus);
 
         List<WebPostResumeResponse.EducationDetails> educationDetails =
-                response.getEducationDetails().stream()
+                response.educationDetails().stream()
                         .map(e -> {
-                            Degree degree = safeConvertToEnum(e.getDegree(), Degree.class, Degree.BACHELOR);
+                            Degree degree = safeConvertToEnum(e.degree(), Degree.class, Degree.BACHELOR);
                             return new WebPostResumeResponse.EducationDetails(
-                                    e.getSchoolName(),
+                                    e.schoolName(),
                                     degree,
-                                    e.getMajor(),
-                                    e.getGpa(),
-                                    e.getMaxGpa()
+                                    e.major(),
+                                    e.gpa(),
+                                    e.maxGpa()
                             );
                         }).toList();
 
         List<WebPostResumeResponse.WorkExperience> workExperiences =
-                response.getWorkExperiences().stream()
+                response.workExperiences().stream()
                         .map(w -> {
-                            Position position = safeConvertToEnum(w.getPosition(), Position.class,
+                            Position position = safeConvertToEnum(w.position(), Position.class,
                                     Position.INTERN);
                             return new WebPostResumeResponse.WorkExperience(
-                                    w.getCompanyName(),
+                                    w.companyName(),
                                     position,
-                                    w.getPeriod()
+                                    w.period()
                             );
                         }).toList();
 
         List<WebPostResumeResponse.Certification> certifications =
-                response.getCertificates().stream()
+                response.certificates().stream()
                         .map(Certification::new)
                         .toList();
 
         List<WebPostResumeResponse.LanguageSkill> languageSkills =
-                response.getLanguageSkills().stream()
+                response.languageSkills().stream()
                         .map(l -> {
-                            LanguageTest languageTest = safeConvertToEnum(l.getLanguageTest(), LanguageTest.class,
+                            LanguageTest languageTest = safeConvertToEnum(l.languageTest(), LanguageTest.class,
                                     LanguageTest.TOEIC_ENGLISH);
                             return new WebPostResumeResponse.LanguageSkill(
                                     languageTest,
-                                    l.getScore()
+                                    l.score()
                             );
                         }).toList();
 
         List<WebPostResumeResponse.Activity> activities =
-                response.getActivities().stream()
+                response.activities().stream()
                         .map(a -> new WebPostResumeResponse.Activity(
-                                a.getName(),
-                                a.getRole(),
-                                a.getAward()
+                                a.name(),
+                                a.role(),
+                                a.award()
                         )).toList();
 
         return new WebPostResumeResponse.ResumeAnalysisResult(

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/request/AiPostResumeRequest.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/request/AiPostResumeRequest.java
@@ -1,12 +1,9 @@
 package kakaotech.bootcamp.respec.specranking.domain.ai.dto.ai.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class AiPostResumeRequest {
-    @JsonProperty("filelink")
-    private final String resumeS3Url;
+public record AiPostResumeRequest(
+        @JsonProperty("filelink")
+        String resumeS3Url
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/request/AiPostSpecRequest.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/request/AiPostSpecRequest.java
@@ -1,7 +1,8 @@
 package kakaotech.bootcamp.respec.specranking.domain.ai.dto.ai.request;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Degree;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.FinalStatus;
@@ -9,73 +10,73 @@ import kakaotech.bootcamp.respec.specranking.domain.common.type.Institute;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.JobField;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.LanguageTest;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Position;
-import lombok.Data;
 
-@Data
-public class AiPostSpecRequest {
+public record AiPostSpecRequest(
+        String nickname,
 
-    private String nickname;
+        @JsonProperty("final_edu")
+        Institute institute,
 
-    @JsonProperty("final_edu")
-    private Institute institute;
+        @JsonProperty("final_status")
+        FinalStatus finalStatus,
 
-    @JsonProperty("final_status")
-    private FinalStatus finalStatus;
+        @JsonProperty("desired_job")
+        JobField jobField,
 
-    @JsonProperty("desired_job")
-    private JobField jobField;
+        @JsonProperty("universities")
+        List<EducationDetail> educationDetails,
 
-    @JsonProperty("universities")
-    private List<EducationDetail> educationDetails = new ArrayList<>();
+        @JsonProperty("careers")
+        List<WorkExperience> workExperiences,
 
-    @JsonProperty("careers")
-    private List<WorkExperience> workExperiences = new ArrayList<>();
+        List<String> certificates,
 
-    private List<String> certificates = new ArrayList<>();
+        @JsonProperty("languages")
+        List<LanguageSkill> languageSkills,
 
-    @JsonProperty("languages")
-    private List<LanguageSkill> languageSkills = new ArrayList<>();
-
-    private List<Activity> activities = new ArrayList<>();
-
-    @Data
-    public static class EducationDetail {
-        @JsonProperty("school_name")
-        private String schoolName;
-
-        private Degree degree;
-
-        private String major;
-
-        private Double gpa;
-
-        @JsonProperty("gpa_max")
-        private Double maxGpa;
+        List<Activity> activities
+) {
+    public AiPostSpecRequest {
+        educationDetails = List.copyOf(requireNonNull(educationDetails));
+        workExperiences = List.copyOf(requireNonNull(workExperiences));
+        certificates = List.copyOf(requireNonNull(certificates));
+        languageSkills = List.copyOf(requireNonNull(languageSkills));
+        activities = List.copyOf(requireNonNull(activities));
     }
 
-    @Data
-    public static class WorkExperience {
-        @JsonProperty("company")
-        private String companyName;
-        @JsonProperty("role")
-        private Position position;
-        @JsonProperty("work_month")
-        private Integer period;
+    public record EducationDetail(
+            @JsonProperty("school_name")
+            String schoolName,
+            Degree degree,
+            String major,
+            Double gpa,
+            @JsonProperty("gpa_max")
+            Double maxGpa
+    ) {
     }
 
-    @Data
-    public static class LanguageSkill {
-        @JsonProperty("test")
-        private LanguageTest languageTest;
-
-        @JsonProperty("score_or_grade")
-        private String score;
+    public record WorkExperience(
+            @JsonProperty("company")
+            String companyName,
+            @JsonProperty("role")
+            Position position,
+            @JsonProperty("work_month")
+            Integer period
+    ) {
     }
 
-    @Data
-    public static class Activity {
-        private String name;
-        private String role;
-        private String award;
+    public record LanguageSkill(
+            @JsonProperty("test")
+            LanguageTest languageTest,
+            @JsonProperty("score_or_grade")
+            String score
+    ) {
+    }
+
+    public record Activity(
+            String name,
+            String role,
+            String award
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/response/AiPostResumeResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/ai/response/AiPostResumeResponse.java
@@ -1,78 +1,74 @@
 package kakaotech.bootcamp.respec.specranking.domain.ai.dto.ai.response;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class AiPostResumeResponse {
-    @JsonProperty("final_edu")
-    private final String institute;
+public record AiPostResumeResponse(
+        @JsonProperty("final_edu")
+        String institute,
 
-    @JsonProperty("final_status")
-    private final String finalStatus;
+        @JsonProperty("final_status")
+        String finalStatus,
 
-    @JsonProperty("desired_job")
-    private final String jobField;
+        @JsonProperty("desired_job")
+        String jobField,
 
-    @JsonProperty("universities")
-    private final List<EducationDetail> educationDetails;
+        @JsonProperty("universities")
+        List<EducationDetail> educationDetails,
 
-    @JsonProperty("careers")
-    private final List<WorkExperience> workExperiences;
+        @JsonProperty("careers")
+        List<WorkExperience> workExperiences,
 
-    private final List<String> certificates;
+        List<String> certificates,
 
-    @JsonProperty("languages")
-    private final List<LanguageSkill> languageSkills;
+        @JsonProperty("languages")
+        List<LanguageSkill> languageSkills,
 
-    private final List<Activity> activities;
-
-    @Getter
-    @RequiredArgsConstructor
-    public static class EducationDetail {
-        @JsonProperty("school_name")
-        private final String schoolName;
-
-        private final String degree;
-
-        private final String major;
-
-        private final Double gpa;
-
-        @JsonProperty("gpa_max")
-        private final Double maxGpa;
-
+        List<Activity> activities
+) {
+    public AiPostResumeResponse {
+        educationDetails = List.copyOf(requireNonNull(educationDetails));
+        workExperiences = List.copyOf(requireNonNull(workExperiences));
+        certificates = List.copyOf(requireNonNull(certificates));
+        languageSkills = List.copyOf(requireNonNull(languageSkills));
+        activities = List.copyOf(requireNonNull(activities));
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class WorkExperience {
-        @JsonProperty("company")
-        private final String companyName;
-        @JsonProperty("role")
-        private final String position;
-        @JsonProperty("work_month")
-        private final Integer period;
+    public record EducationDetail(
+            @JsonProperty("school_name")
+            String schoolName,
+            String degree,
+            String major,
+            Double gpa,
+            @JsonProperty("gpa_max")
+            Double maxGpa
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class LanguageSkill {
-        @JsonProperty("test")
-        private final String languageTest;
-
-        @JsonProperty("score_or_grade")
-        private final String score;
+    public record WorkExperience(
+            @JsonProperty("company")
+            String companyName,
+            @JsonProperty("role")
+            String position,
+            @JsonProperty("work_month")
+            Integer period
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class Activity {
-        private final String name;
-        private final String role;
-        private final String award;
+    public record LanguageSkill(
+            @JsonProperty("test")
+            String languageTest,
+            @JsonProperty("score_or_grade")
+            String score
+    ) {
+    }
+
+    public record Activity(
+            String name,
+            String role,
+            String award
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/web/response/WebPostResumeResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/ai/dto/web/response/WebPostResumeResponse.java
@@ -1,5 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.ai.dto.web.response;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Degree;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.FinalStatus;
@@ -7,71 +9,67 @@ import kakaotech.bootcamp.respec.specranking.domain.common.type.Institute;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.JobField;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.LanguageTest;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Position;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class WebPostResumeResponse {
-    private final Boolean isSuccess;
-    private final String message;
-    private final ResumeAnalysisResult data;
-
-    @Getter
-    @RequiredArgsConstructor
-    public static class ResumeAnalysisResult {
-        private final FinalEducation finalEducation;
-        private final List<EducationDetails> educationDetails;
-        private final List<WorkExperience> workExperiences;
-        private final List<Certification> certifications;
-        private final List<LanguageSkill> languageSkills;
-        private final List<Activity> activities;
-        private final JobField jobField;
+public record WebPostResumeResponse(
+        Boolean isSuccess,
+        String message,
+        ResumeAnalysisResult data
+) {
+    public record ResumeAnalysisResult(
+            FinalEducation finalEducation,
+            List<EducationDetails> educationDetails,
+            List<WorkExperience> workExperiences,
+            List<Certification> certifications,
+            List<LanguageSkill> languageSkills,
+            List<Activity> activities,
+            JobField jobField
+    ) {
+        public ResumeAnalysisResult {
+            educationDetails = List.copyOf(requireNonNull(educationDetails));
+            workExperiences = List.copyOf(requireNonNull(workExperiences));
+            certifications = List.copyOf(requireNonNull(certifications));
+            languageSkills = List.copyOf(requireNonNull(languageSkills));
+            activities = List.copyOf(requireNonNull(activities));
+        }
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class FinalEducation {
-        private final Institute institute;
-        private final FinalStatus finalStatus;
+    public record FinalEducation(
+            Institute institute,
+            FinalStatus finalStatus
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class EducationDetails {
-        private final String schoolName;
-        private final Degree degree;
-        private final String major;
-        private final Double gpa;
-        private final Double maxGpa;
+    public record EducationDetails(
+            String schoolName,
+            Degree degree,
+            String major,
+            Double gpa,
+            Double maxGpa
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class WorkExperience {
-        private final String company;
-        private final Position position;
-        private final Integer period;
+    public record WorkExperience(
+            String company,
+            Position position,
+            Integer period
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class Certification {
-        private final String name;
+    public record Certification(
+            String name
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class LanguageSkill {
-        private final LanguageTest name;
-        private final String score;
+    public record LanguageSkill(
+            LanguageTest name,
+            String score
+    ) {
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    public static class Activity {
-        private final String name;
-        private final String role;
-        private final String award;
+    public record Activity(
+            String name,
+            String role,
+            String award
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/consume/ChatRelayConsumeDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/consume/ChatRelayConsumeDto.java
@@ -1,13 +1,8 @@
 package kakaotech.bootcamp.respec.specranking.domain.chat.dto.consume;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public class ChatRelayConsumeDto {
-    private Long senderId;
-    private Long receiverId;
-    private String content;
-
+public record ChatRelayConsumeDto(
+        Long senderId,
+        Long receiverId,
+        String content
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/produce/ChatProduceDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/produce/ChatProduceDto.java
@@ -1,21 +1,12 @@
 package kakaotech.bootcamp.respec.specranking.domain.chat.dto.produce;
 
 import kakaotech.bootcamp.respec.specranking.domain.common.type.ChatStatus;
-import lombok.Getter;
 
-@Getter
-public class ChatProduceDto {
-    private String idempotentKey;
-    private Long senderId;
-    private Long receiverId;
-    private String content;
-    private ChatStatus status;
-
-    public ChatProduceDto(String idempotentKey, Long senderId, Long receiverId, String content, ChatStatus status) {
-        this.idempotentKey = idempotentKey;
-        this.senderId = senderId;
-        this.receiverId = receiverId;
-        this.content = content;
-        this.status = status;
-    }
+public record ChatProduceDto(
+        String idempotentKey,
+        Long senderId,
+        Long receiverId,
+        String content,
+        ChatStatus status
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/request/SocketChatSendRequest.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/request/SocketChatSendRequest.java
@@ -1,14 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.chat.dto.request;
 
-import lombok.Getter;
-
-@Getter
-public class SocketChatSendRequest {
-    private final Long receiverId;
-    private final String content;
-
-    public SocketChatSendRequest(Long receiverId, String content) {
-        this.receiverId = receiverId;
-        this.content = content;
-    }
+public record SocketChatSendRequest(
+        Long receiverId,
+        String content
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/response/ChatListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/response/ChatListResponse.java
@@ -1,32 +1,29 @@
 package kakaotech.bootcamp.respec.specranking.domain.chat.dto.response;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-public class ChatListResponse {
-    private Boolean isSuccess;
-    private String message;
-    private ChatListData data;
-
-    @Getter
-    @Builder
-    public static class ChatListData {
-        private Long partnerId;
-        private List<ChatMessageDto> messages;
-        private Boolean hasNext;
-        private String nextCursor;
+public record ChatListResponse(
+        Boolean isSuccess,
+        String message,
+        ChatListData data
+) {
+    public record ChatListData(
+            Long partnerId,
+            List<ChatMessageDto> messages,
+            Boolean hasNext,
+            String nextCursor
+    ) {
+        public ChatListData {
+            // 불변 방어 복사
+            messages = List.copyOf(messages);
+        }
     }
 
-    @Getter
-    @AllArgsConstructor
-    public static class ChatMessageDto {
-        private Long messageId;
-        private Long senderId;
-        private String content;
-        private String createdAt;
+    public record ChatMessageDto(
+            Long messageId,
+            Long senderId,
+            String content,
+            String createdAt
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/response/ChatRelayResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/dto/response/ChatRelayResponse.java
@@ -1,13 +1,8 @@
 package kakaotech.bootcamp.respec.specranking.domain.chat.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public class ChatRelayResponse {
-    private Long senderId;
-    private Long receiverId;
-    private String content;
-
+public record ChatRelayResponse(
+        Long senderId,
+        Long receiverId,
+        String content
+) {
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/handler/ChatWebSocketHandler.java
@@ -118,8 +118,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     }
 
     private void processMessage(SocketChatSendRequest incomingMessage, Long senderId) {
-        Long receiverId = incomingMessage.getReceiverId();
-        String content = incomingMessage.getContent();
+        Long receiverId = incomingMessage.receiverId();
+        String content = incomingMessage.content();
         String idempotentKey = UUID.randomUUID().toString();
 
         ChatProduceDto chatProduceDto = new ChatProduceDto(idempotentKey, senderId, receiverId, content, SENT);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/service/ChatQueryService.java
@@ -60,18 +60,9 @@ public class ChatQueryService {
                 ))
                 .collect(Collectors.toList());
 
-        ChatListData data = ChatListData.builder()
-                .partnerId(partnerId)
-                .messages(messageDtos)
-                .hasNext(hasNext)
-                .nextCursor(nextCursor)
-                .build();
+        ChatListData data = new ChatListData(partnerId, messageDtos, hasNext, nextCursor);
 
-        return ChatListResponse.builder()
-                .isSuccess(true)
-                .message("채팅 목록 조회 성공")
-                .data(data)
-                .build();
+        return new ChatListResponse(true, "채팅 목록 조회 성공", data);
     }
 
     private String encodeCursor(Long id) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/service/ChatService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/service/ChatService.java
@@ -25,7 +25,7 @@ public class ChatService {
     private final NotificationService notificationService;
 
     public void sendMessageToUser(ChatRelayConsumeDto chatRelayDto) throws IOException {
-        Long receiverId = chatRelayDto.getReceiverId();
+        Long receiverId = chatRelayDto.receiverId();
 
         WebSocketSession session = webSocketSessionManager.getSessionByUserId(receiverId);
 
@@ -34,11 +34,8 @@ public class ChatService {
             return;
         }
 
-        ChatRelayResponse messageToClient = ChatRelayResponse.builder()
-                .senderId(chatRelayDto.getSenderId())
-                .receiverId(chatRelayDto.getReceiverId())
-                .content(chatRelayDto.getContent())
-                .build();
+        ChatRelayResponse messageToClient = new ChatRelayResponse(chatRelayDto.senderId(), chatRelayDto.receiverId(),
+                chatRelayDto.content());
 
         String messageJson = objectMapper.writeValueAsString(messageToClient);
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/dto/response/ChatParticipationListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/dto/response/ChatParticipationListResponse.java
@@ -2,31 +2,28 @@ package kakaotech.bootcamp.respec.specranking.domain.chatparticipation.dto.respo
 
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-public class ChatParticipationListResponse {
-    private boolean isSuccess;
-    private String message;
-    private ChatParticipationListData data;
+public record ChatParticipationListResponse(
+        boolean isSuccess,
+        String message,
+        ChatParticipationListData data
+) {
 
-    @Getter
-    @Builder
-    public static class ChatParticipationListData {
-        private List<ChatRoomDto> chatRooms;
+    public record ChatParticipationListData(
+            List<ChatRoomDto> chatRooms
+    ) {
+        public ChatParticipationListData {
+            chatRooms = List.copyOf(chatRooms); // 불변 방어 복사
+        }
     }
 
-    @Getter
-    @AllArgsConstructor
-    public static class ChatRoomDto {
-        private Long roomId;
-        private Long partnerId;
-        private String partnerNickname;
-        private String partnerProfileImageUrl;
-        private String lastMessage;
-        private LocalDateTime lastMessageTime;
+    public record ChatRoomDto(
+            Long roomId,
+            Long partnerId,
+            String partnerNickname,
+            String partnerProfileImageUrl,
+            String lastMessage,
+            LocalDateTime lastMessageTime
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/service/ChatParticipationService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chatparticipation/service/ChatParticipationService.java
@@ -66,14 +66,8 @@ public class ChatParticipationService {
                 })
                 .collect(Collectors.toList());
 
-        ChatParticipationListData data = ChatParticipationListData.builder()
-                .chatRooms(chatroomDtos)
-                .build();
+        ChatParticipationListData data = new ChatParticipationListData(chatroomDtos);
 
-        return ChatParticipationListResponse.builder()
-                .isSuccess(true)
-                .message("채팅방 목록 조회 성공")
-                .data(data)
-                .build();
+        return new ChatParticipationListResponse(true, "채팅방 목록 조회 성공", data);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/dto/response/NotificationStatusResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/dto/response/NotificationStatusResponse.java
@@ -1,20 +1,14 @@
 package kakaotech.bootcamp.respec.specranking.domain.notification.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+public record NotificationStatusResponse(
+        boolean isSuccess,
+        String message,
+        NotificationStatusData data
+) {
 
-@Getter
-@Builder
-public class NotificationStatusResponse {
-    private boolean isSuccess;
-    private String message;
-    private NotificationStatusData data;
-
-    @Getter
-    @AllArgsConstructor
-    public static class NotificationStatusData {
-        private boolean hasUnreadChat;
-        private boolean hasUnreadComment;
+    public record NotificationStatusData(
+            boolean hasUnreadChat,
+            boolean hasUnreadComment
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/service/NotificationService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/service/NotificationService.java
@@ -44,11 +44,7 @@ public class NotificationService {
 
         NotificationStatusData data = new NotificationStatusData(hasUnreadChat, hasUnreadComment);
 
-        return NotificationStatusResponse.builder()
-                .isSuccess(true)
-                .message("알림 상태 조회 성공")
-                .data(data)
-                .build();
+        return new NotificationStatusResponse(true, "알림 상태 조회 성공", data);
     }
 
     public void deleteChatNotifications() {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/request/PostSpecRequest.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/request/PostSpecRequest.java
@@ -1,5 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.spec.dto.request;
 
+import static java.util.Objects.requireNonNull;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -7,7 +9,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
-import java.util.ArrayList;
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Degree;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.FinalStatus;
@@ -15,95 +16,80 @@ import kakaotech.bootcamp.respec.specranking.domain.common.type.Institute;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.JobField;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.LanguageTest;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Position;
-import lombok.Data;
 
-@Data
-public class PostSpecRequest {
-    @NotNull(message = "최종 학력 정보는 필수입니다")
-    @Valid
-    private FinalEducation finalEducation;
-    @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
-    @Valid
-    private List<EducationDetail> educationDetails = new ArrayList<>();
-    @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
-    @Valid
-    private List<WorkExperience> workExperiences = new ArrayList<>();
-    @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
-    @Valid
-    private List<Certification> certifications = new ArrayList<>();
-    @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
-    @Valid
-    private List<LanguageSkill> languageSkills = new ArrayList<>();
-    @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
-    @Valid
-    private List<Activity> activities = new ArrayList<>();
-    @NotNull(message = "희망 직무 분야는 필수입니다")
-    private JobField jobField;
+public record PostSpecRequest(
+        @NotNull(message = "최종 학력 정보는 필수입니다")
+        @Valid FinalEducation finalEducation,
 
-    @Data
-    public static class FinalEducation {
-        @NotNull(message = "최종 학력 기관은 필수입니다")
-        private Institute institute;
+        @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
+        @Valid List<EducationDetail> educationDetails,
 
-        @NotNull(message = "최종 학력 상태는 필수입니다")
-        private FinalStatus status;
+        @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
+        @Valid List<WorkExperience> workExperiences,
+
+        @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
+        @Valid List<Certification> certifications,
+
+        @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
+        @Valid List<LanguageSkill> languageSkills,
+
+        @NotNull(message = "null로 보낼 수 없습니다. 값이 없으면 빈 리스트로 보내십시오.")
+        @Valid List<Activity> activities,
+
+        @NotNull(message = "희망 직무 분야는 필수입니다")
+        JobField jobField
+) {
+    public PostSpecRequest {
+        educationDetails = List.copyOf(requireNonNull(educationDetails));
+        workExperiences = List.copyOf(requireNonNull(workExperiences));
+        certifications = List.copyOf(requireNonNull(certifications));
+        languageSkills = List.copyOf(requireNonNull(languageSkills));
+        activities = List.copyOf(requireNonNull(activities));
     }
 
-    @Data
-    public static class EducationDetail {
-        @NotBlank(message = "학교 이름은 필수입니다")
-        private String schoolName;
-        @NotNull(message = "학위 타입은 필수입니다")
-        private Degree degree;
-        @NotBlank(message = "전공은 필수입니다")
-        private String major;
-        @NotNull(message = "학점은 필수입니다")
-        @PositiveOrZero(message = "학점은 0 이상이어야 합니다")
-        private Double gpa;
-        @NotNull(message = "최대 학점은 필수입니다")
-        @Positive(message = "최대 학점은 양수여야 합니다")
-        @Max(value = 5, message = "최대 학점은 5 이하여야 합니다")
-        @Min(value = 4, message = "최대 학점은 4 이상이어야 합니다")
-        private Double maxGpa;
+    public record FinalEducation(
+            @NotNull(message = "최종 학력 기관은 필수입니다") Institute institute,
+            @NotNull(message = "최종 학력 상태는 필수입니다") FinalStatus status
+    ) {
     }
 
-    @Data
-    public static class WorkExperience {
-        @NotBlank(message = "회사명은 필수입니다")
-        private String companyName;
-
-        @NotNull(message = "직무는 필수입니다")
-        private Position position;
-
-        @NotNull(message = "근무 기간은 필수입니다")
-        @Positive(message = "근무 기간은 양수여야 합니다")
-        private Integer period;
+    public record EducationDetail(
+            @NotBlank(message = "학교 이름은 필수입니다") String schoolName,
+            @NotNull(message = "학위 타입은 필수입니다") Degree degree,
+            @NotBlank(message = "전공은 필수입니다") String major,
+            @NotNull(message = "학점은 필수입니다")
+            @PositiveOrZero(message = "학점은 0 이상이어야 합니다") Double gpa,
+            @NotNull(message = "최대 학점은 필수입니다")
+            @Positive(message = "최대 학점은 양수여야 합니다")
+            @Max(value = 5, message = "최대 학점은 5 이하여야 합니다")
+            @Min(value = 4, message = "최대 학점은 4 이상이어야 합니다") Double maxGpa
+    ) {
     }
 
-    @Data
-    public static class Certification {
-        @NotBlank(message = "자격증 이름은 필수입니다")
-        private String name;
+    public record WorkExperience(
+            @NotBlank(message = "회사명은 필수입니다") String companyName,
+            @NotNull(message = "직무는 필수입니다") Position position,
+            @NotNull(message = "근무 기간은 필수입니다")
+            @Positive(message = "근무 기간은 양수여야 합니다") Integer period
+    ) {
     }
 
-    @Data
-    public static class LanguageSkill {
-        @NotNull(message = "어학 시험 이름은 필수입니다")
-        private LanguageTest languageTest;
-
-        @NotBlank(message = "점수는 필수입니다")
-        private String score;
+    public record Certification(
+            @NotBlank(message = "자격증 이름은 필수입니다") String name
+    ) {
     }
 
-    @Data
-    public static class Activity {
-        @NotBlank(message = "활동 이름은 필수입니다")
-        private String name;
+    public record LanguageSkill(
+            @NotNull(message = "어학 시험 이름은 필수입니다") LanguageTest languageTest,
+            @NotBlank(message = "점수는 필수입니다") String score
+    ) {
+    }
 
-        @NotBlank(message = "역할은 필수입니다")
-        private String role;
-
-        @NotNull // NotBlank가 아닌 NotNull이 맞습니다. 수상내역이 없을 경우 ""를 가져옵니다.
-        private String award;
+    public record Activity(
+            @NotBlank(message = "활동 이름은 필수입니다") String name,
+            @NotBlank(message = "역할은 필수입니다") String role,
+            @NotNull(message = "수상내역은 필수입니다") String award
+            // NotBlank가 아닌 NotNull이 맞습니다. 수상내역이 없을 경우 ""를 가져옵니다.
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/RankingResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/RankingResponse.java
@@ -2,50 +2,45 @@ package kakaotech.bootcamp.respec.specranking.domain.spec.dto.response;
 
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.JobField;
-import lombok.Data;
 
-@Data
-public class RankingResponse {
-    private Boolean isSuccess;
-    private String message;
-    private RankingData data;
-
-    @Data
-    public static class RankingData {
-        private List<RankingItem> rankings;
-        private Boolean hasNext;
-        private String nextCursor;
-    }
-
-    @Data
-    public static class RankingItem {
-        private Long userId;
-        private String nickname;
-        private String profileImageUrl;
-        private Long specId;
-        private Double score;
-        private Long totalRank;
-        private Long totalUsersCount;
-        private JobField jobField;
-        private Long rankByJobField;
-        private Long usersCountByJobField;
-        private Boolean isBookmarked;
-        private Long commentsCount;
-        private Long bookmarksCount;
-    }
-
-    public RankingResponse(Boolean isSuccess, String message, RankingData data) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-        this.data = data;
-    }
-
+public record RankingResponse(
+        Boolean isSuccess,
+        String message,
+        RankingData data
+) {
     public static RankingResponse success(List<RankingItem> rankings, Boolean hasNext, String nextCursor) {
-        RankingData data = new RankingData();
-        data.setRankings(rankings);
-        data.setHasNext(hasNext);
-        data.setNextCursor(nextCursor);
-
+        RankingData data = new RankingData(
+                List.copyOf(rankings),
+                hasNext,
+                nextCursor
+        );
         return new RankingResponse(true, "랭킹 목록 조회 성공", data);
+    }
+
+    public record RankingData(
+            List<RankingItem> rankings,
+            Boolean hasNext,
+            String nextCursor
+    ) {
+        public RankingData {
+            rankings = List.copyOf(rankings);
+        }
+    }
+
+    public record RankingItem(
+            Long userId,
+            String nickname,
+            String profileImageUrl,
+            Long specId,
+            Double score,
+            Long totalRank,
+            Long totalUsersCount,
+            JobField jobField,
+            Long rankByJobField,
+            Long usersCountByJobField,
+            Boolean isBookmarked,
+            Long commentsCount,
+            Long bookmarksCount
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/SearchResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/SearchResponse.java
@@ -2,53 +2,46 @@ package kakaotech.bootcamp.respec.specranking.domain.spec.dto.response;
 
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.JobField;
-import lombok.Data;
 
-@Data
-public class SearchResponse {
-    private Boolean isSuccess;
-    private String message;
-    private SearchData data;
-
-    @Data
-    public static class SearchData {
-        private String keyword;
-        private List<SearchResult> results;
-        private Boolean hasNext;
-        private String nextCursor;
-    }
-
-    @Data
-    public static class SearchResult {
-        private Long userId;
-        private String nickname;
-        private String profileImageUrl;
-        private Long specId;
-        private Double score;
-        private Long totalRank;
-        private Long totalUsersCount;
-        private JobField jobField;
-        private Long rankByJobField;
-        private Long totalUsersCountByJobField;
-        private Boolean isBookmarked;
-        private Long commentsCount;
-        private Long bookmarksCount;
-    }
-
-    public SearchResponse(Boolean isSuccess, String message, SearchData data) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-        this.data = data;
-    }
-
+public record SearchResponse(
+        Boolean isSuccess,
+        String message,
+        SearchData data
+) {
     public static SearchResponse success(String keyword, List<SearchResult> results, Boolean hasNext,
                                          String nextCursor) {
-        SearchData data = new SearchData();
-        data.setKeyword(keyword);
-        data.setResults(results);
-        data.setHasNext(hasNext);
-        data.setNextCursor(nextCursor);
+        return new SearchResponse(
+                true,
+                "검색 목록 조회 성공",
+                new SearchData(keyword, List.copyOf(results), hasNext, nextCursor)
+        );
+    }
 
-        return new SearchResponse(true, "검색 목록 조회 성공", data);
+    public record SearchData(
+            String keyword,
+            List<SearchResult> results,
+            Boolean hasNext,
+            String nextCursor
+    ) {
+        public SearchData {
+            results = List.copyOf(results); // 방어적 복사
+        }
+    }
+
+    public record SearchResult(
+            Long userId,
+            String nickname,
+            String profileImageUrl,
+            Long specId,
+            Double score,
+            Long totalRank,
+            Long totalUsersCount,
+            JobField jobField,
+            Long rankByJobField,
+            Long totalUsersCountByJobField,
+            Boolean isBookmarked,
+            Long commentsCount,
+            Long bookmarksCount
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/SpecDetailResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/SpecDetailResponse.java
@@ -8,91 +8,94 @@ import kakaotech.bootcamp.respec.specranking.domain.common.type.JobField;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.LanguageTest;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.Position;
 import kakaotech.bootcamp.respec.specranking.domain.common.type.ScoreCategoryDetail;
-import lombok.Data;
 
-@Data
-public class SpecDetailResponse {
-    private Boolean isSuccess;
-    private String message;
-    private SpecDetailData specDetailData;
+public record SpecDetailResponse(
+        Boolean isSuccess,
+        String message,
+        SpecDetailData specDetailData
+) {
 
-    @Data
-    public static class SpecDetailData {
-        private FinalEducation finalEducation;
-        private List<EducationDetails> educationDetails;
-        private List<WorkExperience> workExperiences;
-        private List<Certification> certifications;
-        private List<LanguageSkill> languageSkills;
-        private List<Activity> activities;
-        private JobField jobField;
-        private Rankings rankings;
-        private String assessment;
+    public record SpecDetailData(
+            FinalEducation finalEducation,
+            List<EducationDetails> educationDetails,
+            List<WorkExperience> workExperiences,
+            List<Certification> certifications,
+            List<LanguageSkill> languageSkills,
+            List<Activity> activities,
+            JobField jobField,
+            Rankings rankings,
+            String assessment
+    ) {
+        public SpecDetailData {
+            educationDetails = List.copyOf(educationDetails);
+            workExperiences = List.copyOf(workExperiences);
+            certifications = List.copyOf(certifications);
+            languageSkills = List.copyOf(languageSkills);
+            activities = List.copyOf(activities);
+        }
     }
 
-    @Data
-    public static class FinalEducation {
-        private Institute institute;
-        private FinalStatus finalStatus;
+    public record FinalEducation(
+            Institute institute,
+            FinalStatus finalStatus
+    ) {
     }
 
-    @Data
-    public static class EducationDetails {
-        private String schoolName;
-        private Degree degree;
-        private String major;
-        private Double gpa;
-        private Double maxGpa;
+    public record EducationDetails(
+            String schoolName,
+            Degree degree,
+            String major,
+            Double gpa,
+            Double maxGpa
+    ) {
     }
 
-    @Data
-    public static class WorkExperience {
-        private String company;
-        private Position position;
-        private Integer period;
+    public record WorkExperience(
+            String company,
+            Position position,
+            Integer period
+    ) {
     }
 
-    @Data
-    public static class Certification {
-        private String name;
+    public record Certification(
+            String name
+    ) {
     }
 
-    @Data
-    public static class LanguageSkill {
-        private LanguageTest name;
-        private String score;
+    public record LanguageSkill(
+            LanguageTest name,
+            String score
+    ) {
     }
 
-    @Data
-    public static class Activity {
-        private String name;
-        private String role;
-        private String award;
+    public record Activity(
+            String name,
+            String role,
+            String award
+    ) {
     }
 
-    @Data
-    public static class Rankings {
-        private Details details;
-        private List<ScoreDetail> categories;
+    public record Rankings(
+            Details details,
+            List<ScoreDetail> categories
+    ) {
+        public Rankings {
+            categories = List.copyOf(categories);
+        }
     }
 
-    @Data
-    public static class Details {
-        private Double score;
-        private Long jobFieldRank;
-        private Long jobFieldUserCount;
-        private Long TotalRank;
-        private Long TotalUserCount;
+    public record Details(
+            Double score,
+            Long jobFieldRank,
+            Long jobFieldUserCount,
+            Long TotalRank,
+            Long TotalUserCount
+    ) {
     }
 
-    @Data
-    public static class ScoreDetail {
-        private ScoreCategoryDetail name;
-        private Double score;
-    }
-
-    public SpecDetailResponse(Boolean isSuccess, String message, SpecDetailData specDetailData) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-        this.specDetailData = specDetailData;
+    public record ScoreDetail(
+            ScoreCategoryDetail name,
+            Double score
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/SpecMetaResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/dto/response/SpecMetaResponse.java
@@ -1,27 +1,13 @@
 package kakaotech.bootcamp.respec.specranking.domain.spec.dto.response;
 
-import lombok.Data;
-
-@Data
-public class SpecMetaResponse {
-    private Boolean isSuccess;
-    private String message;
-    private Meta data;
-
-    @Data
-    public static class Meta {
-        private Long totalUserCount;
-        private double averageScore;
-
-        public Meta(Long totalUserCount, double averageScore) {
-            this.totalUserCount = totalUserCount;
-            this.averageScore = averageScore;
-        }
-    }
-
-    public SpecMetaResponse(Boolean isSuccess, String message, Meta data) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-        this.data = data;
+public record SpecMetaResponse(
+        Boolean isSuccess,
+        String message,
+        Meta data
+) {
+    public record Meta(
+            Long totalUserCount,
+            double averageScore
+    ) {
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecQueryService.java
@@ -66,20 +66,13 @@ public class SpecQueryService {
             Long totalUserCount = userRepository.countUsersHavingSpec();
             Long usersCountByJobField = specRepository.countByJobField(specJobField);
 
-            RankingResponse.RankingItem item = new RankingResponse.RankingItem();
-            item.setUserId(user.getId());
-            item.setNickname(user.getNickname());
-            item.setProfileImageUrl(user.getUserProfileUrl());
-            item.setSpecId(spec.getId());
-            item.setJobField(specJobField);
-            item.setScore(totalAnalysisScore);
-            item.setTotalRank(totalRank);
-            item.setTotalUsersCount(totalUserCount);
-            item.setRankByJobField(jobFieldRank);
-            item.setUsersCountByJobField(usersCountByJobField);
-            item.setIsBookmarked(bookmarkedSpecIds.contains(spec.getId()));
-            item.setCommentsCount(commentsCount);
-            item.setBookmarksCount(bookmarksCount);
+            RankingResponse.RankingItem item = new RankingResponse.RankingItem(
+                    user.getId(), user.getNickname(),
+                    user.getUserProfileUrl(), spec.getId(),
+                    totalAnalysisScore, totalRank, totalUserCount,
+                    specJobField, jobFieldRank, usersCountByJobField,
+                    bookmarkedSpecIds.contains(spec.getId()),
+                    commentsCount, bookmarksCount);
 
             rankingItems.add(item);
         }
@@ -107,7 +100,7 @@ public class SpecQueryService {
         if (userId.isPresent()) {
             bookmarkedSpecIds = bookmarkRepository.findSpecIdsByUserId(userId.get());
         }
-        
+
         List<SearchResponse.SearchResult> searchResults = new ArrayList<>();
 
         for (Spec spec : specs) {
@@ -124,20 +117,21 @@ public class SpecQueryService {
             Long totalUserCount = userRepository.countUsersHavingSpec();
             Long totalUsersCountByJobField = specRepository.countByJobField(jobField);
 
-            SearchResponse.SearchResult item = new SearchResponse.SearchResult();
-            item.setUserId(user.getId());
-            item.setNickname(user.getNickname());
-            item.setProfileImageUrl(user.getUserProfileUrl());
-            item.setSpecId(spec.getId());
-            item.setJobField(jobField);
-            item.setScore(averageScore);
-            item.setTotalRank(currentRank);
-            item.setTotalUsersCount(totalUserCount);
-            item.setRankByJobField(jobFieldRank);
-            item.setTotalUsersCountByJobField(totalUsersCountByJobField);
-            item.setIsBookmarked(bookmarkedSpecIds.contains(spec.getId()));
-            item.setCommentsCount(commentsCount);
-            item.setBookmarksCount(bookmarksCount);
+            SearchResponse.SearchResult item = new SearchResponse.SearchResult(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getUserProfileUrl(),
+                    spec.getId(),
+                    averageScore,
+                    currentRank,
+                    totalUserCount,
+                    jobField,
+                    jobFieldRank,
+                    totalUsersCountByJobField,
+                    bookmarkedSpecIds.contains(spec.getId()),
+                    commentsCount,
+                    bookmarksCount
+            );
 
             searchResults.add(item);
         }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/service/SpecService.java
@@ -92,7 +92,7 @@ public class SpecService {
     }
 
     private void saveSpecWithChaining(PostSpecRequest request, AiPostSpecResponse aiPostSpecResponse, User user) {
-        Spec newSpec = Spec.createFromAiResponse(user, request.getJobField(), aiPostSpecResponse);
+        Spec newSpec = Spec.createFromAiResponse(user, request.jobField(), aiPostSpecResponse);
         Spec savedNewSpec = specRepository.save(newSpec);
 
         saveEducation(savedNewSpec, request);
@@ -103,24 +103,24 @@ public class SpecService {
     }
 
     private void saveEducation(Spec spec, PostSpecRequest request) {
-        if (isNotEmpty(request.getFinalEducation())) {
-            FinalStatus status = request.getFinalEducation().getStatus();
-            Institute institute = request.getFinalEducation().getInstitute();
+        if (isNotEmpty(request.finalEducation())) {
+            FinalStatus status = request.finalEducation().status();
+            Institute institute = request.finalEducation().institute();
 
             Education education = new Education(spec, institute, status);
             Education savedEducation = educationRepository.save(education);
 
-            if (isNotEmpty(request.getEducationDetails())) {
-                for (EducationDetail educationDetailDto : request.getEducationDetails()) {
-                    Degree degree = educationDetailDto.getDegree();
+            if (isNotEmpty(request.educationDetails())) {
+                for (EducationDetail educationDetailDto : request.educationDetails()) {
+                    Degree degree = educationDetailDto.degree();
 
                     kakaotech.bootcamp.respec.specranking.domain.educationdetail.entity.EducationDetail educationDetail = new kakaotech.bootcamp.respec.specranking.domain.educationdetail.entity.EducationDetail(
                             savedEducation,
-                            educationDetailDto.getSchoolName(),
+                            educationDetailDto.schoolName(),
                             degree,
-                            educationDetailDto.getMajor(),
-                            educationDetailDto.getGpa(),
-                            educationDetailDto.getMaxGpa()
+                            educationDetailDto.major(),
+                            educationDetailDto.gpa(),
+                            educationDetailDto.maxGpa()
                     );
 
                     educationDetailRepository.save(educationDetail);
@@ -130,15 +130,15 @@ public class SpecService {
     }
 
     private void saveWorkExperience(Spec spec, PostSpecRequest request) {
-        if (isNotEmpty(request.getWorkExperiences())) {
-            for (PostSpecRequest.WorkExperience workExp : request.getWorkExperiences()) {
-                Position position = workExp.getPosition();
+        if (isNotEmpty(request.workExperiences())) {
+            for (PostSpecRequest.WorkExperience workExp : request.workExperiences()) {
+                Position position = workExp.position();
 
                 WorkExperience workExperience = new WorkExperience(
                         spec,
-                        workExp.getCompanyName(),
+                        workExp.companyName(),
                         position,
-                        workExp.getPeriod()
+                        workExp.period()
                 );
 
                 workExperienceRepository.save(workExperience);
@@ -147,11 +147,11 @@ public class SpecService {
     }
 
     private void saveCertifications(Spec spec, PostSpecRequest request) {
-        if (isNotEmpty(request.getCertifications())) {
-            for (PostSpecRequest.Certification certificationDto : request.getCertifications()) {
+        if (isNotEmpty(request.certifications())) {
+            for (PostSpecRequest.Certification certificationDto : request.certifications()) {
                 Certification certification = new Certification(
                         spec,
-                        certificationDto.getName()
+                        certificationDto.name()
                 );
                 certificationRepository.save(certification);
             }
@@ -159,12 +159,12 @@ public class SpecService {
     }
 
     private void saveLanguageSkills(Spec spec, PostSpecRequest request) {
-        if (isNotEmpty(request.getLanguageSkills())) {
-            for (PostSpecRequest.LanguageSkill languageSkillDto : request.getLanguageSkills()) {
+        if (isNotEmpty(request.languageSkills())) {
+            for (PostSpecRequest.LanguageSkill languageSkillDto : request.languageSkills()) {
                 LanguageSkill languageSkill = new LanguageSkill(
                         spec,
-                        languageSkillDto.getLanguageTest(),
-                        languageSkillDto.getScore()
+                        languageSkillDto.languageTest(),
+                        languageSkillDto.score()
                 );
                 languageSkillRepository.save(languageSkill);
             }
@@ -172,13 +172,13 @@ public class SpecService {
     }
 
     private void saveActivities(Spec spec, PostSpecRequest request) {
-        if (isNotEmpty(request.getActivities())) {
-            for (PostSpecRequest.Activity activityDto : request.getActivities()) {
+        if (isNotEmpty(request.activities())) {
+            for (PostSpecRequest.Activity activityDto : request.activities()) {
                 ActivityNetworking activity = new ActivityNetworking(
                         spec,
-                        activityDto.getName(),
-                        activityDto.getRole(),
-                        activityDto.getAward()
+                        activityDto.name(),
+                        activityDto.role(),
+                        activityDto.award()
                 );
                 activityNetworkingRepository.save(activity);
             }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/dto/SimpleResponseDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/dto/SimpleResponseDto.java
@@ -1,15 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.global.dto;
 
-import lombok.Data;
-
-@Data
-public class SimpleResponseDto {
-    private Boolean isSuccess;
-    private String message;
-
-    public SimpleResponseDto(Boolean isSuccess, String message) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-    }
+public record SimpleResponseDto(
+        Boolean isSuccess,
+        String message
+) {
 }
-


### PR DESCRIPTION
## ☝️ 요약

dto를 모두 record로 변경한다.

## ✏️ 상세 내용

- builder
  set을 중간에 하나 빼먹을 위험이 존재한다.

- final 생성자 방식 
 Jackson이 getter, setter에 의존하는 문제점이 존재한다.
 따라서 isSuccess 필드가 success로 json이 나가는 문제점이 있다.


record 방식을 도입한다.

## ✅ 체크리스트

- [x] 모든 기능이 정상적으로 동작하는 지 테스트 해보았습니다. 
