### PR TITLE
refactor: 커스텀 예외 처리 추가, 즐겨찾기 등록.해제 기능 리팩토링

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/constants/BookmarkMessages.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/constants/BookmarkMessages.java
@@ -1,0 +1,4 @@
+package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.constants;
+
+public class BookmarkMessages {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/constants/BookmarkMessages.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/constants/BookmarkMessages.java
@@ -1,4 +1,9 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.constants;
 
 public class BookmarkMessages {
+
+    public static final String BOOKMARK_CREATE_SUCCESS = "즐겨찾기 등록 성공";
+    public static final String BOOKMARK_DELETE_SUCCESS = "즐겨찾기 해제 성공";
+
+    private BookmarkMessages() {}
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/constants/BookmarkMessages.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/constants/BookmarkMessages.java
@@ -4,6 +4,7 @@ public class BookmarkMessages {
 
     public static final String BOOKMARK_CREATE_SUCCESS = "즐겨찾기 등록 성공";
     public static final String BOOKMARK_DELETE_SUCCESS = "즐겨찾기 해제 성공";
+    public static final String GET_BOOKMARK_LIST_SUCCESS = "즐겨찾기 목록 조회 성공";
 
     private BookmarkMessages() {}
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/controller/BookmarkController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/controller/BookmarkController.java
@@ -1,5 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.controller;
 
+import jakarta.validation.constraints.Positive;
+import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.constants.BookmarkMessages;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.dto.BookmarkCreateResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.dto.BookmarkListResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.service.BookmarkQueryService;
@@ -7,33 +9,43 @@ import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.service.Book
 import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @RequestMapping("/api/bookmarks")
 @RequiredArgsConstructor
 public class BookmarkController {
 
+    private static final String DEFAULT_LIMIT = "10";
+
     private final BookmarkService bookmarkService;
-    private final BookmarkQueryService bookmarkqueryService;
+    private final BookmarkQueryService bookmarkQueryService;
 
     @GetMapping
     public BookmarkListResponse getBookmarkList(
             @RequestParam(value = "cursor", required = false) String cursor,
-            @RequestParam(value = "limit", defaultValue = "10") int limit) {
-        return bookmarkqueryService.getBookmarkList(cursor, limit);
+            @RequestParam(value = "limit", defaultValue = DEFAULT_LIMIT) int limit) {
+        return bookmarkQueryService.getBookmarkList(cursor, limit);
     }
 
     @PostMapping("/specs/{specId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public BookmarkCreateResponse createBookmark(@PathVariable Long specId) {
+    public BookmarkCreateResponse createBookmark(
+            @PathVariable
+            @Positive(message = "specId는 양수여야 합니다.")
+            Long specId) {
         Long bookmarkId = bookmarkService.createBookmark(specId);
-        return new BookmarkCreateResponse(true, "즐겨찾기 등록 성공", bookmarkId);
+        return BookmarkCreateResponse.success(BookmarkMessages.BOOKMARK_CREATE_SUCCESS, bookmarkId);
     }
 
     @DeleteMapping("/specs/{specId}")
-    public SimpleResponseDto deleteBookmark(@PathVariable Long specId) {
+    public SimpleResponseDto deleteBookmark(
+            @PathVariable
+            @Positive(message = "specId는 양수여야 합니다.")
+            Long specId) {
         bookmarkService.deleteBookmark(specId);
-        return new SimpleResponseDto(true, "즐겨찾기 해제 성공");
+        return SimpleResponseDto.success(BookmarkMessages.BOOKMARK_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkCreateResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkCreateResponse.java
@@ -1,16 +1,11 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.dto;
 
-import lombok.Data;
-
-@Data
-public class BookmarkCreateResponse {
-    private Boolean isSuccess;
-    private String message;
-    private Long bookmarkId;
-
-    public BookmarkCreateResponse(Boolean isSuccess, String message, Long bookmarkId) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-        this.bookmarkId = bookmarkId;
+public record BookmarkCreateResponse (
+        Boolean isSuccess,
+        String message,
+        Long bookmarkId
+) {
+    public static BookmarkCreateResponse success(String message, Long bookmarkId) {
+        return new BookmarkCreateResponse(true, message, bookmarkId);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkListResponse.java
@@ -1,83 +1,34 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.dto;
 
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
-import lombok.Data;
 
 import java.util.List;
 
-@Data
-public class BookmarkListResponse {
-    private Boolean isSuccess;
-    private String message;
-    private BookmarkListData data;
+public record BookmarkListResponse (
+        Boolean isSuccess,
+        String message,
+        BookmarkListData data
+) {
+    public record BookmarkListData (
+            List<BookmarkItem> bookmarks,
+            Boolean hasNext,
+            String nextCursor
+    ) {}
 
-    @Data
-    public static class BookmarkListData {
-        private List<BookmarkItem> bookmarks;
-        private Boolean hasNext;
-        private String nextCursor;
+    public record BookmarkItem (
+        Long id,
+        SpecInfo spec
+    ) {}
 
-        public BookmarkListData(List<BookmarkItem> bookmarks, Boolean hasNext, String nextCursor) {
-            this.bookmarks = bookmarks;
-            this.hasNext = hasNext;
-            this.nextCursor = nextCursor;
-        }
-    }
+    public record SpecInfo (
+            Long id, Long userId, String nickname, String profileImageUrl,
+            Double score, Long totalRank, Long totalUserCount,
+            Long jobFieldRank, Long jobFieldUserCount, JobField jobField,
+            Boolean isBookmarked, Long commentsCount, Long bookmarksCount
+    ) {}
 
-    @Data
-    public static class BookmarkItem {
-        private Long id;
-        private SpecInfo spec;
-
-        public BookmarkItem(Long id, SpecInfo spec) {
-            this.id = id;
-            this.spec = spec;
-        }
-    }
-
-    @Data
-    public static class SpecInfo {
-        private Long id;
-        private Long userId;
-        private String nickname;
-        private String profileImageUrl;
-        private Double score;
-        private Long totalRank;
-        private Long totalUserCount;
-        private Long jobFieldRank;
-        private Long jobFieldUserCount;
-        private JobField jobField;
-        private Boolean isBookmarked;
-        private Long commentsCount;
-        private Long bookmarksCount;
-
-        public SpecInfo(Long id, Long userId, String nickname, String profileImageUrl, Double score,
-                        Long totalRank, Long totalUserCount, Long jobFieldRank, Long jobFieldUserCount,
-                        JobField jobField, Boolean isBookmarked, Long commentsCount, Long bookmarksCount) {
-            this.id = id;
-            this.userId = userId;
-            this.nickname = nickname;
-            this.profileImageUrl = profileImageUrl;
-            this.score = score;
-            this.totalRank = totalRank;
-            this.totalUserCount = totalUserCount;
-            this.jobFieldRank = jobFieldRank;
-            this.jobFieldUserCount = jobFieldUserCount;
-            this.jobField = jobField;
-            this.isBookmarked = isBookmarked;
-            this.commentsCount = commentsCount;
-            this.bookmarksCount = bookmarksCount;
-        }
-    }
-
-    public BookmarkListResponse(Boolean isSuccess, String message, BookmarkListData data) {
-        this.isSuccess = isSuccess;
-        this.message = message;
-        this.data = data;
-    }
-
-    public static BookmarkListResponse success(List<BookmarkItem> bookmarks, Boolean hasNext, String nextCursor) {
-        BookmarkListData data = new BookmarkListData(bookmarks, hasNext, nextCursor);
-        return new BookmarkListResponse(true, "즐겨찾기 목록 조회 성공", data);
+    public static BookmarkListResponse success(List<BookmarkItem> bookmarks, Boolean hasNext, String nextCursor, String message) {
+        BookmarkListData bookmarkListData = new BookmarkListData(bookmarks, hasNext, nextCursor);
+        return new BookmarkListResponse(true, message, bookmarkListData);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/repository/BookmarkRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, BookmarkRepositoryCustom {
 
     @Query("SELECT b.spec.id FROM Bookmark b WHERE b.user.id = :userId")
     List<Long> findSpecIdsByUserId(@Param("userId") Long userId);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/repository/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/repository/BookmarkRepositoryCustomImpl.java
@@ -22,18 +22,30 @@ public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
 
     @Override
     public List<Bookmark> findBookmarksByUserIdWithCursor(Long userId, Long cursorId, int limit) {
-        if (cursorId == null) {
-            return queryFactory
-                    .selectFrom(bookmark)
-                    .where(
-                            bookmark.user.id.eq(userId),
-                            spec.status.eq(SpecStatus.ACTIVE)
-                    )
-                    .orderBy(bookmark.id.desc())
-                    .limit(limit)
-                    .fetch();
+        if (isFirstPage(cursorId)) {
+            return findBookmarksFromFirstPage(userId, limit);
         }
 
+        return findBookmarksFromCursor(userId, cursorId, limit);
+    }
+
+    private boolean isFirstPage(Long cursorId) {
+        return cursorId == null || cursorId.equals(Long.MAX_VALUE);
+    }
+
+    private List<Bookmark> findBookmarksFromFirstPage(Long userId, int limit) {
+        return queryFactory
+                .selectFrom(bookmark)
+                .where(
+                        bookmark.user.id.eq(userId),
+                        spec.status.eq(SpecStatus.ACTIVE)
+                )
+                .orderBy(bookmark.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    private List<Bookmark> findBookmarksFromCursor(Long userId, Long cursorId, int limit) {
         return queryFactory
                 .selectFrom(bookmark)
                 .where(

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/service/BookmarkQueryService.java
@@ -1,14 +1,12 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.service;
 
-import jakarta.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Optional;
+
+import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.constants.BookmarkMessages;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.dto.BookmarkListResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.entity.Bookmark;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.repository.BookmarkRepository;
-import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.repository.BookmarkRepositoryCustomImpl;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
@@ -16,90 +14,109 @@ import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
 import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
 import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BookmarkQueryService {
 
-    private final BookmarkRepositoryCustomImpl bookmarkRepositoryCustomImpl;
     private final BookmarkRepository bookmarkRepository;
     private final CommentRepository commentRepository;
     private final SpecRepository specRepository;
     private final UserRepository userRepository;
 
     public BookmarkListResponse getBookmarkList(String cursor, int limit) {
-        Optional<Long> optUserId = UserUtils.getCurrentUserId();
-        Long userId = optUserId.orElseThrow(() -> new IllegalArgumentException("로그인이 필요한 서비스입니다."));
-        userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Long currentUserId = getCurrentUserIdOrThrow();
+        validateUserExists(currentUserId);
 
-        Long cursorId = decodeCursor(cursor);
-        List<Bookmark> bookmarks = bookmarkRepositoryCustomImpl.findBookmarksByUserIdWithCursor(userId, cursorId,
-                limit + 1);
+        Long decodedCursorId = decodeCursor(cursor);
+        List<Bookmark> bookmarks = bookmarkRepository.findBookmarksByUserIdWithCursor(currentUserId, decodedCursorId, limit + 1);
 
+        BookmarkPaginationResult paginationResult = createPagination(bookmarks, limit);
+        List<BookmarkListResponse.BookmarkItem> bookmarkItems = buildBookmarkItems(paginationResult.bookmarks());
+
+        return BookmarkListResponse.success(
+                bookmarkItems,
+                paginationResult.hasNext(),
+                paginationResult.nextCursor(),
+                BookmarkMessages.GET_BOOKMARK_LIST_SUCCESS
+        );
+    }
+
+    private Long getCurrentUserIdOrThrow() {
+        return UserUtils.getCurrentUserId()
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+    }
+
+    private void validateUserExists(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    private BookmarkPaginationResult createPagination(List<Bookmark> bookmarks, int limit) {
         boolean hasNext = bookmarks.size() > limit;
         String nextCursor = null;
+
         if (hasNext) {
             bookmarks = bookmarks.subList(0, limit);
             nextCursor = encodeCursor(bookmarks.getLast().getId());
         }
 
-        List<BookmarkListResponse.BookmarkItem> bookmarkItems = new ArrayList<>();
+        return new BookmarkPaginationResult(bookmarks, hasNext, nextCursor);
+    }
 
-        for (Bookmark bookmark : bookmarks) {
-            Spec spec = bookmark.getSpec();
-            User specUser = spec.getUser();
-            JobField jobField = spec.getJobField();
+    private List<BookmarkListResponse.BookmarkItem> buildBookmarkItems(List<Bookmark> bookmarks) {
+        return bookmarks.stream().map(this::buildBookmarkItem).toList();
+    }
 
-            Double score = spec.getTotalAnalysisScore();
-            Long totalRank = specRepository.findAbsoluteRankByJobField(JobField.TOTAL, spec.getId());
-            Long totalUserCount = userRepository.countUsersHavingSpec();
-            Long jobFieldRank = specRepository.findAbsoluteRankByJobField(jobField, spec.getId());
-            Long jobFieldUserCount = specRepository.countByJobField(jobField);
+    private BookmarkListResponse.BookmarkItem buildBookmarkItem(Bookmark bookmark) {
+        Spec spec = bookmark.getSpec();
+        BookmarkListResponse.SpecInfo specInfo = buildSpecInfo(spec);
+        return new BookmarkListResponse.BookmarkItem(bookmark.getId(), specInfo);
+    }
 
-            Long commentsCount = commentRepository.countBySpecId(spec.getId());
-            Long bookmarksCount = bookmarkRepository.countBySpecId(spec.getId());
+    private BookmarkListResponse.SpecInfo buildSpecInfo(Spec spec) {
+        User specOwner = spec.getUser();
+        JobField jobField = spec.getJobField();
+        Double score = spec.getTotalAnalysisScore();
 
-            BookmarkListResponse.SpecInfo specInfo = new BookmarkListResponse.SpecInfo(
-                    spec.getId(),
-                    specUser.getId(),
-                    specUser.getNickname(),
-                    specUser.getUserProfileUrl(),
-                    score,
-                    totalRank,
-                    totalUserCount,
-                    jobFieldRank,
-                    jobFieldUserCount,
-                    jobField,
-                    true,
-                    commentsCount,
-                    bookmarksCount
-            );
+        Long totalRank = specRepository.findAbsoluteRankByJobField(JobField.TOTAL, spec.getId());
+        Long totalUserCount = userRepository.countUsersHavingSpec();
+        Long jobFieldRank = specRepository.findAbsoluteRankByJobField(jobField, spec.getId());
+        Long jobFieldUserCount = specRepository.countByJobField(jobField);
 
-            BookmarkListResponse.BookmarkItem bookmarkItem = new BookmarkListResponse.BookmarkItem(
-                    bookmark.getId(),
-                    specInfo
-            );
+        Long commentsCount = commentRepository.countBySpecId(spec.getId());
+        Long bookmarksCount = bookmarkRepository.countBySpecId(spec.getId());
 
-            bookmarkItems.add(bookmarkItem);
-        }
-
-        return BookmarkListResponse.success(bookmarkItems, hasNext, nextCursor);
+        return new BookmarkListResponse.SpecInfo(
+                spec.getId(), specOwner.getId(), specOwner.getNickname(), specOwner.getUserProfileUrl(),
+                score, totalRank, totalUserCount, jobFieldRank, jobFieldUserCount, jobField,
+                true, commentsCount, bookmarksCount
+        );
     }
 
     private String encodeCursor(Long cursorId) {
+        if (cursorId == null) return null;
         return Base64.getEncoder().encodeToString(String.valueOf(cursorId).getBytes());
     }
 
     private Long decodeCursor(String cursor) {
-        if (cursor == null || cursor.isEmpty()) {
-            return Long.MAX_VALUE;
-        }
+        if (cursor == null || cursor.isEmpty()) return Long.MAX_VALUE;
 
         byte[] decodedBytes = Base64.getDecoder().decode(cursor);
         String decodedString = new String(decodedBytes);
         return Long.parseLong(decodedString);
     }
+
+    private record BookmarkPaginationResult(
+            List<Bookmark> bookmarks,
+            boolean hasNext,
+            String nextCursor
+    ) {}
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/dto/ErrorResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/dto/ErrorResponse.java
@@ -1,0 +1,12 @@
+package kakaotech.bootcamp.respec.specranking.global.dto;
+
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+
+public record ErrorResponse (
+        Boolean isSuccess,
+        String message
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(false, errorCode.getMessage());
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/dto/SimpleResponseDto.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/dto/SimpleResponseDto.java
@@ -4,4 +4,7 @@ public record SimpleResponseDto(
         Boolean isSuccess,
         String message
 ) {
+    public static SimpleResponseDto success(String message) {
+        return new SimpleResponseDto(true, message);
+    }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/CustomException.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package kakaotech.bootcamp.respec.specranking.global.exception;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode errorCode() { return errorCode; }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/ErrorCode.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     SELF_BOOKMARK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자신의 스펙은 즐겨찾기할 수 없습니다."),
 
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/ErrorCode.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package kakaotech.bootcamp.respec.specranking.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+
+    SPEC_NOT_FOUND(HttpStatus.NOT_FOUND, "스펙을 찾을 수 없습니다."),
+    SPEC_ACCESS_DENIED(HttpStatus.FORBIDDEN, "스펙에 접근할 권한이 없습니다."),
+
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾을 수 없습니다."),
+    BOOKMARK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기에 등록된 스펙입니다."),
+    SELF_BOOKMARK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자신의 스펙은 즐겨찾기할 수 없습니다."),
+
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() { return httpStatus; }
+    public String getMessage() { return message; }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/GlobalExceptionHandler.java
@@ -43,8 +43,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         return ResponseEntity
-                .status(HttpStatus.PAYLOAD_TOO_LARGE)
-                .body(new ErrorResponse(false, e.getMessage()));
+                .status(ErrorCode.FILE_SIZE_EXCEEDED.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEEDED));
     }
 
     @ExceptionHandler(IllegalStateException.class)


### PR DESCRIPTION
## ☝️ 요약
커스텀 예외 처리 추가, 즐겨찾기 등록.해제 기능 리팩토링

<br/>

## ✏️ 상세 내용
- 커스텀 예외 처리 추가
  - global/exception 패키지에 CustomException, ErrorCode 추가함
  - global/dto 패키지에 ErrorResponse 추가함
  - 에러 메시지는 ErrorCode에 모두 저장하면 됨
  
- 즐겨찾기 등록.해제 기능 리팩토링
  - constants/BookmarkMessages에 성공 메시지 담아둠
  - BookmarkController에 파라미터 관련 Validation 추가
  - BookmarkCreateResponse를 @Data 선언 방식에서 record 클래스로 변환함
  - BookmarkService에서 명확한 함수 분리 및 하드코딩 제거

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] Postman 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
