### PR TITLE
feat: meta-data query cache-aside 전략 개발

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -16,6 +16,7 @@ import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserReposito
 import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -139,6 +140,11 @@ public class SpecQueryService {
         return SearchResponse.success(keyword, searchResults, hasNext, nextCursor);
     }
 
+    @Cacheable(
+            value = "specMetadata",
+            key = "#jobField.name()",
+            unless = "#result == null"
+    )
     public Meta getMetaData(JobField jobField) {
         long totalUserCount = 0;
         Double averageScore = 0.0;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/CacheConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/CacheConfig.java
@@ -1,0 +1,43 @@
+package kakaotech.bootcamp.respec.specranking.global.common.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        cacheConfigurations.put("specMetadata", createCacheConfig(Duration.ofHours(2)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(createCacheConfig(Duration.ofMinutes(30)))
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+
+    private RedisCacheConfiguration createCacheConfig(Duration ttl) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(ttl)
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    }
+}


### PR DESCRIPTION
## ☝️ 요약

meta-data query cache-aside 전략 개발

## ✏️ 상세 내용

meta-data의 경우 '잘 바뀌지 않는 쿼리' 이다.
또한 잠시 총 사용자의 수, 평균 점수가 정합성이 맞지 않아도 문제가 없다
따라서 ttl 기반의 cache-aside 전략이 어울린다.
이를 개발한다.

## ✅ 체크리스트

- [x] 레디스에 해당 캐시가 잘 들어가는가?
- [x] 기능이 정상적으로 동작하는가?
