### PR TITLE
feat: getSpecDetail 캐시 적용

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecDetailQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecDetailQueryService.java
@@ -27,6 +27,7 @@ import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 import kakaotech.bootcamp.respec.specranking.global.common.type.ScoreCategoryDetail;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +44,9 @@ public class SpecDetailQueryService {
     private final LanguageSkillRepository languageSkillRepository;
     private final ActivityNetworkingRepository activityNetworkingRepository;
 
+    @Cacheable(value = "specDetail",
+            key = "#specId",
+            unless = "#result == null")
     public SpecDetailResponse getSpecDetail(Long specId) {
         Spec spec = specRepository.findById(specId)
                 .orElseThrow(() -> new IllegalArgumentException("Spec not found"));

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/CacheConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/CacheConfig.java
@@ -24,6 +24,7 @@ public class CacheConfig {
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 
         cacheConfigurations.put("specMetadata", createCacheConfig(Duration.ofHours(2)));
+        cacheConfigurations.put("specDetails", createCacheConfig(Duration.ofMinutes(3)));
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(createCacheConfig(Duration.ofMinutes(30)))


### PR DESCRIPTION
## ☝️ 요약

스펙 상세 조회 캐싱 적용

## ✏️ 상세 내용

getSpecDetail은 특정 사용자의 스펙을 조회하면 호출되는 메서드이다.
서비스 특성상 어떤 '인기있는' 유저의 스펙을 많이 조회하게 된다.
이를 캐시 한다면 DB 부하를 막을 수 있다.
ttl을 3분으로 설정하여 인기있는 스펙에 대해서는 캐시된 데이터를 가져오도록 한다.
ttl을 설정하는 이유는 최근 인기있는 스펙에 대해서 캐싱을 하기 위함이다.


## ✅ 체크리스트

- [x] 캐싱이 레디스에 정상적으로 들어가는가?
- [x] 기능이 정상적으로 동작하는가?