### PR TITLE
chore: timezone asia시간으로 어플리케이션 설정

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/SpecRankingApplication.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/SpecRankingApplication.java
@@ -1,5 +1,7 @@
 package kakaotech.bootcamp.respec.specranking;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -9,6 +11,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 public class SpecRankingApplication {
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(SpecRankingApplication.class, args);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/JpaAuditingConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package kakaotech.bootcamp.respec.specranking.global.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/SchedulingConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package kakaotech.bootcamp.respec.specranking.global.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/TimeZoneConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/TimeZoneConfig.java
@@ -1,0 +1,14 @@
+package kakaotech.bootcamp.respec.specranking.global.common.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeZoneConfig {
+
+    @PostConstruct
+    public void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}


### PR DESCRIPTION
## ☝️ 요약

timezone asia시간으로 어플리케이션 설정

## ✏️ 상세 내용

ec2 시간으로 rds에 저장이 되는 현상 발생.
어플리케이션의 시간이 ec2 시간으로 설정되어 있음.
어플리케이션의 시간을 seoul 시간으로 설정.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.