### PR TITLE
refactor: 파라미터에 대한 예외처리 추가, bookmark와 comment 도메인에서 Boolean을 모두 boolean으로 수정

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkCreateResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkCreateResponse.java
@@ -1,7 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.bookmark.dto;
 
 public record BookmarkCreateResponse (
-        Boolean isSuccess,
+        boolean isSuccess,
         String message,
         Long bookmarkId
 ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/bookmark/dto/BookmarkListResponse.java
@@ -5,7 +5,7 @@ import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 import java.util.List;
 
 public record BookmarkListResponse (
-        Boolean isSuccess,
+        boolean isSuccess,
         String message,
         BookmarkListData data
 ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/CommentListResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/CommentListResponse.java
@@ -3,7 +3,7 @@ package kakaotech.bootcamp.respec.specranking.domain.social.comment.dto;
 import java.util.List;
 
 public record CommentListResponse (
-        Boolean isSuccess,
+        boolean isSuccess,
         String message,
         CommentListData data
 ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/CommentPostResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/CommentPostResponse.java
@@ -1,7 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.dto;
 
 public record CommentPostResponse (
-        Boolean isSuccess,
+        boolean isSuccess,
         String message,
         CommentData data
 ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/CommentUpdateResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/CommentUpdateResponse.java
@@ -1,7 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.dto;
 
 public record CommentUpdateResponse (
-        Boolean isSuccess,
+        boolean isSuccess,
         String message,
         CommentUpdateData data
 ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/ReplyPostResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/dto/ReplyPostResponse.java
@@ -1,7 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.dto;
 
 public record ReplyPostResponse (
-        Boolean isSuccess,
+        boolean isSuccess,
         String message,
         ReplyData data
 ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @ControllerAdvice
@@ -19,6 +20,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(false, e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
## ☝️ 요약
파라미터에 대한 예외처리 추가, bookmark와 comment 도메인에서 Boolean을 모두 boolean으로 수정

<br/>

## ✏️ 상세 내용
- Controller에서 @PathVariable에 맞지 않는 타입이 들어오면 MethodArgumentTypeMismatchException 발생함
  - 해당 예외처리를 GlobalExceptionHandler에 추가함

- Bookmark, Comment 도메인 내 dto에 선언된 Boolean을 모두 boolean으로 수정함
  - dto를 record 클래스로 변경해서 이제 isSuccess가 success로 반환되는 문제가 발생하지 않음
  - boolean은 true, false만 허용하지만 Boolean은 true, false, null을 허용해 더 명확한 것은 boolean 타입임
  - Boolean이 boolean보다 차지하는 메모리가 큼. 성능적으로 boolean이 더 효율적
    
    - Boolean은 참조타입, 128bit <-> boolean은 원시타입, 1bit

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 로컬 테스트 완료했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
