### PR TITLE
feat: 채팅 접속시 redis에 ip를 넣을때 ttl을 24시간으로 설정한다.

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/handler/ChatWebSocketHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chat.dto.request.SocketChatSendRequest;
@@ -40,7 +41,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
         Long userId = (Long) session.getAttributes().get("userId");
 
-        redisTemplate.opsForValue().set("chat:user:" + userId, privateAddress);
+        redisTemplate.opsForValue().set("chat:user:" + userId, privateAddress, Duration.ofHours(24));
         webSocketSessionManager.addSession(userId, session);
     }
 


### PR DESCRIPTION
## ☝️ 요약

채팅 접속시 redis에 ip를 넣을때 ttl을 24시간으로 설정한다.

## ✏️ 상세 내용

원래는 ttl이 존재하지 않았다.
하지만 ec2 서버가 모종의 이유로 종료되었을때 redis에 있는 ip를 제거할 수 없게 된다. 혹여나 그런 상황을 대비하여 24시간 ttl을 설정한다.
채팅을 오랫동안 하는 유저는 24시간 동안 채팅을 할 수 있으므로 24시간을 기준으로 한다.

## ✅ 체크리스트

- [x] ttl이 정상적으로 적용되는가?
- [x] 모든 기능이 정상적으로 동작하는가?