### PR TITLE
feat: 스펙 등록, 수정 멱등키를 이용해 멱등성 보장

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/request/PostSpecRequest.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/request/PostSpecRequest.java
@@ -18,6 +18,9 @@ import kakaotech.bootcamp.respec.specranking.global.common.type.LanguageTest;
 import kakaotech.bootcamp.respec.specranking.global.common.type.Position;
 
 public record PostSpecRequest(
+        @NotBlank(message = "멱등키는 필수입니다.")
+        @Valid String idempotentKey,
+
         @NotNull(message = "최종 학력 정보는 필수입니다")
         @Valid FinalEducation finalEducation,
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/infrastructure/redis/service/IdempotencyService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/infrastructure/redis/service/IdempotencyService.java
@@ -1,0 +1,27 @@
+package kakaotech.bootcamp.respec.specranking.global.infrastructure.redis.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Boolean setIfAbsent(String key, Duration ttl) {
+        final String DUMMY_VALUE = "1";
+        return redisTemplate.opsForValue().setIfAbsent(key, DUMMY_VALUE, ttl);
+    }
+
+    public boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+}


### PR DESCRIPTION
## ☝️ 요약

스펙 등록, 수정 멱등키를 이용해 멱등성 보장

## ✏️ 상세 내용

스펙 페이지 입력, 수정에서 클릭을 빠르게 한다면, 멱등성이 보장되지 않는 문제가 발생할 수 있다.
사용자는 무의식적으로 마우스 클릭을 여러번 할 수 있다. 이럴때에 같은 여러 스펙이 생성되면 안된다.
이를 멱등키를 이용하여 하나만 생성함을 보장한다.

## ✅ 체크리스트

- [x] 기존 기능이 정상적으로 돌아가는 지 확인한다.
- [x] 멱등키 기능이 정상적으로 동작하는지 확인한다.
