### PR TITLE
feat: 커버 기반 페이지네이션 랭킹 캐시 적용

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -30,7 +30,9 @@ public class SpecQueryService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
 
+    @Cacheable(value = "top10Rankings", key = "#jobField", condition = "#cursor == null")
     public RankingResponse getRankings(JobField jobField, String cursor, int limit) {
+
         Long cursorId = decodeCursor(cursor);
 
         List<Spec> specs = specRepository.findTopSpecsByJobFieldWithCursor(jobField, cursorId, limit + 1);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/CacheConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/config/CacheConfig.java
@@ -25,6 +25,7 @@ public class CacheConfig {
 
         cacheConfigurations.put("specMetadata", createCacheConfig(Duration.ofHours(2)));
         cacheConfigurations.put("specDetails", createCacheConfig(Duration.ofMinutes(3)));
+        cacheConfigurations.put("top10Rankings", createCacheConfig(Duration.ofSeconds(30)));
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(createCacheConfig(Duration.ofMinutes(30)))


### PR DESCRIPTION
## ☝️ 요약

커버 기반 페이지네이션 랭킹 캐시 적용

## ✏️ 상세 내용

30초를 ttl을 두어 첫 페이지네이션을 캐싱 합니다.


## ✅ 체크리스트

- [x] 모든 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 캐싱이 적용되는지 확인했습니다.