### PR TITLE
refactor: 댓글 조회 기능 controller, validator 분리

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/controller/CommentController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/controller/CommentController.java
@@ -2,21 +2,16 @@ package kakaotech.bootcamp.respec.specranking.domain.social.comment.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentListResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentPostResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentRequest;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentUpdateResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.ReplyPostResponse;
-import kakaotech.bootcamp.respec.specranking.domain.social.comment.service.CommentQueryService;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.service.CommentService;
 import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
-    private final CommentQueryService commentQueryService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -64,12 +58,5 @@ public class CommentController {
             @PathVariable @Positive(message = "스펙 ID는 양수여야 합니다.") Long specId,
             @PathVariable @Positive(message = "댓글 ID는 양수여야 합니다.") Long commentId) {
         return commentService.deleteComment(specId, commentId);
-    }
-
-    @GetMapping
-    public CommentListResponse getComments(
-            @PathVariable @Positive(message = "스펙 ID는 양수여야 합니다.") Long specId,
-            @PageableDefault(size = 5) Pageable pageable) {
-        return commentQueryService.getComments(specId, pageable);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/controller/CommentQueryController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/controller/CommentQueryController.java
@@ -1,0 +1,26 @@
+package kakaotech.bootcamp.respec.specranking.domain.social.comment.controller;
+
+import jakarta.validation.constraints.Positive;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentListResponse;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.service.CommentQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequestMapping("/api/specs/{specId}/comments")
+@RequiredArgsConstructor
+public class CommentQueryController {
+
+    private final CommentQueryService commentQueryService;
+
+    @GetMapping
+    public CommentListResponse getComments(
+            @PathVariable @Positive(message = "스펙 ID는 양수여야 합니다.") Long specId,
+            @PageableDefault(size = 5) Pageable pageable) {
+        return commentQueryService.getComments(specId, pageable);
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentQueryService.java
@@ -3,7 +3,7 @@ package kakaotech.bootcamp.respec.specranking.domain.social.comment.service;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.constants.CommentMessages;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentListResponse;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
-import kakaotech.bootcamp.respec.specranking.domain.social.comment.validator.CommentValidator;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.validator.CommentQueryValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,11 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentQueryService {
 
     private final CommentRepository commentRepository;
-    private final CommentValidator commentValidator;
+    private final CommentQueryValidator commentQueryValidator;
 
     public CommentListResponse getComments(Long specId, Pageable pageable) {
 
-        commentValidator.validateSpecExists(specId);
+        commentQueryValidator.validateSpecExists(specId);
 
         Page<CommentListResponse.CommentWithReplies> commentsPage = commentRepository.findCommentsWithReplies(specId,
                 pageable);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentService.java
@@ -66,7 +66,7 @@ public class CommentService {
         User user = getCurrentUser();
         Comment targetComment = findCommentByIdAndSpecId(commentId, specId);
 
-        commentValidator.validateCommentOwner(targetComment, user);
+        commentValidator.validateCommentUpdate(targetComment, user);
 
         targetComment.updateContent(request.content());
         Comment updatedComment = commentRepository.save(targetComment);

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentQueryValidator.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentQueryValidator.java
@@ -1,0 +1,20 @@
+package kakaotech.bootcamp.respec.specranking.domain.social.comment.validator;
+
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
+import kakaotech.bootcamp.respec.specranking.global.common.type.SpecStatus;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentQueryValidator {
+
+    private final SpecRepository specRepository;
+
+    public void validateSpecExists(Long specId) {
+        specRepository.findByIdAndStatus(specId, SpecStatus.ACTIVE)
+                .orElseThrow(() -> new CustomException(ErrorCode.SPEC_NOT_FOUND));
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentValidator.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentValidator.java
@@ -2,9 +2,7 @@ package kakaotech.bootcamp.respec.specranking.domain.social.comment.validator;
 
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
-import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
 import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
-import kakaotech.bootcamp.respec.specranking.global.common.type.SpecStatus;
 import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
 import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +12,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CommentValidator {
 
-    private final SpecRepository specRepository;
-
     public void validateReplyCreation(Comment parentComment, Spec spec) {
         validateCommentBelongsToSpec(parentComment, spec);
         validateReplyDepth(parentComment);
+    }
+
+    public void validateCommentUpdate(Comment comment, User user) {
+        validateCommentOwner(comment, user);
+        validateCommentNotDeleted(comment);
     }
 
     public void validateCommentDeletion(Comment comment, User user) {
@@ -30,11 +31,6 @@ public class CommentValidator {
         if (!comment.isWrittenBy(user)) {
             throw new CustomException(ErrorCode.COMMENT_ACCESS_DENIED);
         }
-    }
-
-    public void validateSpecExists(Long specId) {
-        specRepository.findByIdAndStatus(specId, SpecStatus.ACTIVE)
-                .orElseThrow(() -> new CustomException(ErrorCode.SPEC_NOT_FOUND));
     }
 
     private void validateCommentBelongsToSpec(Comment comment, Spec spec) {


### PR DESCRIPTION
## ☝️ 요약
댓글 조회 기능 controller, validator 분리

<br/>

## ✏️ 상세 내용
- 수정 전 : controller, validator 클래스가 각각 하나씩 존재함
- 수정 후 : 댓글 조회 기능만 다루는 controller, validator 클래스가 하나씩 추가됨
- 테스트 코드 작성 시 불필요한 의존성 주입을 하지 않기 위해 기능별로 클래스를 분리하기로 결정함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 로컬 테스트 완료했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
