### PR TITLE
test: 댓글 CUD 기능 service단 테스트코드 작성

### DIFF
--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentCreateServiceTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentCreateServiceTest.java
@@ -1,4 +1,166 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.service;
 
-public class CommentCreateServiceTest {
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.constants.CommentMessages;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentPostResponse;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentRequest;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
+import kakaotech.bootcamp.respec.specranking.fixture.CommentFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.SpecFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.UserFixture;
+import kakaotech.bootcamp.respec.specranking.global.common.type.SpecStatus;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("댓글 생성 서비스 테스트")
+class CommentCreateServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private SpecRepository specRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    //====================================================================
+    // Common Failure Tests : UNAUTHORIZED, USER_NOT_FOUND, SPEC_NOT_FOUND
+    //====================================================================
+
+    @Test
+    @DisplayName("공통 실패: 사용자가 인증되지 않음")
+    void createComment_Unauthorized_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(DEFAULT_COMMENT_CONTENT);
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupUnauthenticatedUser(mockUserUtils);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createComment(DEFAULT_SPEC_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.UNAUTHORIZED.getMessage());
+
+            then(commentRepository).shouldHaveNoInteractions();
+        }
+    }
+
+    @Test
+    @DisplayName("공통 실패: 사용자를 찾을 수 없음")
+    void createComment_UserNotFound_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(DEFAULT_COMMENT_CONTENT);
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createComment(DEFAULT_SPEC_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("공통 실패: 스펙을 찾을 수 없음")
+    void createComment_SpecNotFound_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(DEFAULT_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(NON_EXISTENT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createComment(NON_EXISTENT_SPEC_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.SPEC_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("성공: 정상적인 댓글 생성")
+    void createComment_Success() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(DEFAULT_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Spec mockSpec = SpecFixture.createMockSpec();
+        Comment mockComment = CommentFixture.createMockComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.of(mockSpec));
+            given(commentRepository.findMaxBundleBySpecId(DEFAULT_SPEC_ID)).willReturn(EXISTING_MAX_BUNDLE_NUMBER);
+            given(commentRepository.save(Mockito.any(Comment.class))).willReturn(mockComment);
+
+            // when
+            CommentPostResponse response = commentService.createComment(DEFAULT_SPEC_ID, commentRequest);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.message()).isEqualTo(CommentMessages.COMMENT_CREATE_SUCCESS);
+            assertThat(response.data()).isNotNull();
+
+            then(commentRepository).should().save(Mockito.any(Comment.class));
+        }
+    }
+
+    @Test
+    @DisplayName("성공: 첫 번째 댓글 생성 (번들 번호 1)")
+    void createComment_FirstComment_BundleNumberOne() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(FIRST_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Spec mockSpec = SpecFixture.createMockSpec();
+        Comment mockComment = CommentFixture.createMockComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.of(mockSpec));
+            given(commentRepository.findMaxBundleBySpecId(DEFAULT_SPEC_ID)).willReturn(null);
+            given(commentRepository.save(Mockito.any(Comment.class))).willReturn(mockComment);
+
+            // when
+            CommentPostResponse response = commentService.createComment(DEFAULT_SPEC_ID, commentRequest);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isSuccess()).isTrue();
+            then(commentRepository).should().save(Mockito.any(Comment.class));
+        }
+    }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentDeleteServiceTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentDeleteServiceTest.java
@@ -1,4 +1,71 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.service;
 
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.constants.CommentMessages;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.validator.CommentValidator;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
+import kakaotech.bootcamp.respec.specranking.fixture.CommentFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.UserFixture;
+import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("댓글 삭제 서비스 테스트")
 public class CommentDeleteServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommentValidator commentValidator;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("성공: 정상적인 댓글 삭제")
+    void deleteComment_Success() {
+        // given
+        User mockUser = UserFixture.createMockUser();
+        Comment mockComment = CommentFixture.createMockComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(commentRepository.findByIdAndSpecId(DEFAULT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockComment));
+            willDoNothing().given(commentValidator).validateCommentDeletion(mockComment, mockUser);
+            given(commentRepository.save(mockComment)).willReturn(mockComment);
+
+            // when
+            SimpleResponseDto response = commentService.deleteComment(DEFAULT_SPEC_ID, DEFAULT_COMMENT_ID);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.message()).isEqualTo(CommentMessages.COMMENT_DELETE_SUCCESS);
+
+            then(commentValidator).should().validateCommentDeletion(mockComment, mockUser);
+            then(commentRepository).should().save(mockComment);
+        }
+    }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentUpdateServiceTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/CommentUpdateServiceTest.java
@@ -1,4 +1,155 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.service;
 
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.constants.CommentMessages;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentRequest;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentUpdateResponse;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.validator.CommentValidator;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
+import kakaotech.bootcamp.respec.specranking.fixture.CommentFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.UserFixture;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("댓글 수정 서비스 테스트")
 public class CommentUpdateServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommentValidator commentValidator;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    //=========================================================================================
+    // Common Failure Tests : COMMENT_NOT_FOUND, COMMENT_ACCESS_DENIED, COMMENT_ALREADY_DELETED
+    //=========================================================================================
+
+    @Test
+    @DisplayName("공통 실패: 댓글을 찾을 수 없음")
+    void updateComment_CommentNotFound_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(UPDATED_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(commentRepository.findByIdAndSpecId(NON_EXISTENT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> commentService.updateComment(DEFAULT_SPEC_ID, NON_EXISTENT_COMMENT_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+
+            then(commentValidator).shouldHaveNoInteractions();
+        }
+    }
+
+    @Test
+    @DisplayName("공통 실패: 유효성 검증 실패 - 댓글 수정/삭제 권한 없음")
+    void updateComment_NoPermission_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(UPDATED_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Comment mockComment = CommentFixture.createMockComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(commentRepository.findByIdAndSpecId(DEFAULT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockComment));
+            willThrow(new CustomException(ErrorCode.COMMENT_ACCESS_DENIED))
+                    .given(commentValidator).validateCommentUpdate(mockComment, mockUser);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.updateComment(DEFAULT_SPEC_ID, DEFAULT_COMMENT_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_ACCESS_DENIED.getMessage());
+
+            then(commentRepository).should(never()).save(Mockito.any(Comment.class));
+        }
+    }
+
+    @Test
+    @DisplayName("공통 실패: 유효성 검증 실패 - 이미 삭제된 댓글 수정/삭제 시도")
+    void updateComment_commentAlreadyDeleted_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(UPDATED_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Comment mockComment = CommentFixture.createMockComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(commentRepository.findByIdAndSpecId(DEFAULT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockComment));
+            willThrow(new CustomException(ErrorCode.COMMENT_ALREADY_DELETED))
+                    .given(commentValidator).validateCommentUpdate(mockComment, mockUser);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.updateComment(DEFAULT_SPEC_ID, DEFAULT_COMMENT_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_ALREADY_DELETED.getMessage());
+
+            then(commentRepository).should(never()).save(Mockito.any(Comment.class));
+        }
+    }
+
+    @Test
+    @DisplayName("성공: 정상적인 댓글 수정")
+    void updateComment_Success() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(UPDATED_COMMENT_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Comment mockComment = CommentFixture.createMockComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(commentRepository.findByIdAndSpecId(DEFAULT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockComment));
+            willDoNothing().given(commentValidator).validateCommentUpdate(mockComment, mockUser);
+            given(commentRepository.save(mockComment)).willReturn(mockComment);
+
+            // when
+            CommentUpdateResponse response = commentService.updateComment(DEFAULT_SPEC_ID, DEFAULT_COMMENT_ID, commentRequest);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.message()).isEqualTo(CommentMessages.COMMENT_UPDATE_SUCCESS);
+            assertThat(response.data()).isNotNull();
+
+            then(commentValidator).should().validateCommentUpdate(mockComment, mockUser);
+            then(commentRepository).should().save(mockComment);
+        }
+    }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/ReplyCreateServiceTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/service/ReplyCreateServiceTest.java
@@ -1,4 +1,169 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment.service;
 
-public class ReplyCreateServiceTest {
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.constants.CommentMessages;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentRequest;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.ReplyPostResponse;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.validator.CommentValidator;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
+import kakaotech.bootcamp.respec.specranking.fixture.CommentFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.SpecFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.UserFixture;
+import kakaotech.bootcamp.respec.specranking.global.common.type.SpecStatus;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("대댓글 생성 서비스 테스트")
+class ReplyCreateServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private SpecRepository specRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommentValidator commentValidator;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("성공: 정상적인 대댓글 생성")
+    void createReply_Success() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(REPLY_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Spec mockSpec = SpecFixture.createMockSpec();
+        Comment mockParentComment = CommentFixture.createMockParentComment();
+        Comment mockReply = CommentFixture.createMockReply();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.of(mockSpec));
+            given(commentRepository.findByIdAndSpecId(DEFAULT_PARENT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockParentComment));
+            willDoNothing().given(commentValidator).validateReplyCreation(mockParentComment, mockSpec);
+            given(commentRepository.save(Mockito.any(Comment.class))).willReturn(mockReply);
+
+            // when
+            ReplyPostResponse response = commentService.createReply(DEFAULT_SPEC_ID, DEFAULT_PARENT_COMMENT_ID, commentRequest);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.message()).isEqualTo(CommentMessages.REPLY_CREATE_SUCCESS);
+            assertThat(response.data()).isNotNull();
+
+            then(commentValidator).should().validateReplyCreation(mockParentComment, mockSpec);
+            then(commentRepository).should().save(Mockito.any(Comment.class));
+        }
+    }
+
+    @Test
+    @DisplayName("실패: 부모 댓글을 찾을 수 없음")
+    void createReply_ParentCommentNotFound_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(REPLY_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Spec mockSpec = SpecFixture.createMockSpec();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.of(mockSpec));
+            given(commentRepository.findByIdAndSpecId(NON_EXISTENT_COMMENT_ID, DEFAULT_SPEC_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createReply(DEFAULT_SPEC_ID, NON_EXISTENT_COMMENT_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+
+            then(commentValidator).shouldHaveNoInteractions();
+        }
+    }
+
+    @Test
+    @DisplayName("실패: 유효성 검증 실패 - 대댓글에 대댓글 생성 시도")
+    void createReply_ReplyDepthExceeds_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(REPLY_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Spec mockSpec = SpecFixture.createMockSpec();
+        Comment mockNonRootComment = CommentFixture.createMockNonRootComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.of(mockSpec));
+            given(commentRepository.findByIdAndSpecId(REPLY_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockNonRootComment));
+            willThrow(new CustomException(ErrorCode.REPLY_DEPTH_EXCEEDED))
+                    .given(commentValidator).validateReplyCreation(mockNonRootComment, mockSpec);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createReply(DEFAULT_SPEC_ID, REPLY_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.REPLY_DEPTH_EXCEEDED.getMessage());
+
+            then(commentRepository).should().findByIdAndSpecId(REPLY_ID, DEFAULT_SPEC_ID);
+            then(commentRepository).should(never()).save(Mockito.any(Comment.class));
+        }
+    }
+
+    @Test
+    @DisplayName("실패: 유효성 검증 실패 - 부모 댓글이 해당 스펙에 속하지 않음")
+    void createReply_CommentSpecMismatch_ThrowsException() {
+        // given
+        CommentRequest commentRequest = new CommentRequest(REPLY_CONTENT);
+        User mockUser = UserFixture.createMockUser();
+        Spec mockSpec = SpecFixture.createMockSpec();
+        Comment mockParentComment = CommentFixture.createMockParentComment();
+
+        try (MockedStatic<UserUtils> mockUserUtils = Mockito.mockStatic(UserUtils.class)) {
+            UserFixture.setupAuthenticatedUser(mockUserUtils);
+
+            given(userRepository.findById(DEFAULT_USER_ID)).willReturn(Optional.of(mockUser));
+            given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE)).willReturn(Optional.of(mockSpec));
+            given(commentRepository.findByIdAndSpecId(REPLY_ID, DEFAULT_SPEC_ID)).willReturn(Optional.of(mockParentComment));
+            willThrow(new CustomException(ErrorCode.COMMENT_SPEC_MISMATCH))
+                    .given(commentValidator).validateReplyCreation(mockParentComment, mockSpec);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createReply(DEFAULT_SPEC_ID, REPLY_ID, commentRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_SPEC_MISMATCH.getMessage());
+
+            then(commentRepository).should().findByIdAndSpecId(REPLY_ID, DEFAULT_SPEC_ID);
+            then(commentRepository).should(never()).save(Mockito.any(Comment.class));
+        }
+    }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/CommentFixture.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/CommentFixture.java
@@ -1,4 +1,39 @@
 package kakaotech.bootcamp.respec.specranking.fixture;
 
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import org.mockito.Mockito;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.mockito.Mockito.lenient;
+
 public class CommentFixture {
+
+    public static Comment createMockComment() {
+        return createMockComment(DEFAULT_COMMENT_ID, DEFAULT_COMMENT_CONTENT, ROOT_COMMENT_DEPTH, null);
+    }
+
+    public static Comment createMockParentComment() {
+        return createMockComment(DEFAULT_PARENT_COMMENT_ID, DEFAULT_COMMENT_CONTENT, ROOT_COMMENT_DEPTH, null);
+    }
+
+    public static Comment createMockReply() {
+        return createMockComment(REPLY_ID, REPLY_CONTENT, REPLY_DEPTH, DEFAULT_PARENT_COMMENT_ID);
+    }
+
+    public static Comment createMockComment(Long commentId, String content, Integer depth, Long parentCommentId) {
+        Comment comment = Mockito.mock(Comment.class);
+        lenient().when(comment.getId()).thenReturn(commentId);
+        lenient().when(comment.getContent()).thenReturn(content);
+        lenient().when(comment.getDepth()).thenReturn(depth);
+        lenient().when(comment.getParentCommentId()).thenReturn(parentCommentId);
+        return comment;
+    }
+
+    public static Comment createMockNonRootComment() {
+        Comment comment = createMockReply();
+        lenient().when(comment.isRootComment()).thenReturn(false);
+        return comment;
+    }
+
+    private CommentFixture() { }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/SpecFixture.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/SpecFixture.java
@@ -1,4 +1,22 @@
 package kakaotech.bootcamp.respec.specranking.fixture;
 
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import org.mockito.Mockito;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.mockito.Mockito.lenient;
+
 public class SpecFixture {
+
+    public static Spec createMockSpec() {
+        return createMockSpec(DEFAULT_SPEC_ID);
+    }
+
+    public static Spec createMockSpec(Long specId) {
+        Spec spec = Mockito.mock(Spec.class);
+        lenient().when(spec.getId()).thenReturn(specId);
+        return spec;
+    }
+
+    private SpecFixture() { }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/TestConstants.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/TestConstants.java
@@ -11,15 +11,28 @@ public class TestConstants {
     public static final String ANOTHER_USER_PROFILE_URL = "https://example.com/another-profile.jpg";
 
     public static final Long DEFAULT_SPEC_ID = 1L;
+    public static final Long NON_EXISTENT_SPEC_ID = 999L;
 
     public static final Long DEFAULT_COMMENT_ID = 2L;
+    public static final Long DEFAULT_PARENT_COMMENT_ID = 3L;
+    public static final Long REPLY_ID = 4L;
+    public static final Long NON_EXISTENT_COMMENT_ID = 999L;
 
     public static final String DEFAULT_COMMENT_CONTENT = "테스트 댓글 내용";
+    public static final String REPLY_CONTENT = "대댓글 내용";
+    public static final String UPDATED_COMMENT_CONTENT = "수정된 댓글 내용";
+    public static final String FIRST_COMMENT_CONTENT = "첫 번째 댓글";
 
     public static final String DEFAULT_CREATED_AT = "2025-01-01T10:00:00";
     public static final String DEFAULT_UPDATED_AT = "2025-01-01T10:00:00";
     public static final String REPLY_CREATED_AT = "2025-01-01T11:00:00";
     public static final String REPLY_UPDATED_AT = "2025-01-01T11:00:00";
+
+    public static final Integer INITIAL_BUNDLE_NUMBER = 1;
+    public static final Integer EXISTING_MAX_BUNDLE_NUMBER = 5;
+
+    public static final Integer ROOT_COMMENT_DEPTH = 0;
+    public static final Integer REPLY_DEPTH = 1;
 
     private TestConstants() { }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/UserFixture.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/UserFixture.java
@@ -1,4 +1,40 @@
 package kakaotech.bootcamp.respec.specranking.fixture;
 
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.util.UserUtils;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.mockito.Mockito.lenient;
+
 public class UserFixture {
+
+    public static User createMockUser() {
+        return createMockUser(DEFAULT_USER_ID, DEFAULT_USER_NICKNAME, DEFAULT_USER_PROFILE_URL);
+    }
+
+    public static User createMockUser(Long userId, String nickname, String profileUrl) {
+        User user = Mockito.mock(User.class);
+        lenient().when(user.getId()).thenReturn(userId);
+        lenient().when(user.getNickname()).thenReturn(nickname);
+        lenient().when(user.getUserProfileUrl()).thenReturn(profileUrl);
+        return user;
+    }
+
+    public static void setupAuthenticatedUser(MockedStatic<UserUtils> mockUserUtils) {
+        setupAuthenticatedUser(mockUserUtils, DEFAULT_USER_ID);
+    }
+
+    public static void setupAuthenticatedUser(MockedStatic<UserUtils> mockUserUtils, Long userId) {
+        mockUserUtils.when(UserUtils::getCurrentUserId).thenReturn(Optional.of(userId));
+    }
+
+    public static void setupUnauthenticatedUser(MockedStatic<UserUtils> mockUserUtils) {
+        mockUserUtils.when(UserUtils::getCurrentUserId).thenReturn(Optional.empty());
+    }
+
+    private UserFixture() { }
 }


### PR DESCRIPTION
## ☝️ 요약
댓글 CUD 기능 service단 테스트코드 작성

<br/>

## ✏️ 상세 내용

- TestConstants : 댓글 CUD 기능에 필요한 상수 추가
- UserFixture, SpecFixture, CommentFixture : 댓글 CUD 기능에 자주 쓰이는 메소드 모아두는 클래스
- 중복되는 테스트 케이스들은 한 번만 테스트하도록 구현함
  
  - 완전히 동일한 로직 -> CommentCreateServiceTest에서만 구현함
    
    - 사용자 인증 실패 (UNAUTHORIZED)에 대한 예외 처리 로직
    - 사용자를 찾을 수 없음 (USER_NOT_FOUND)에 대한 예외 처리 로직
    - 스펙을 찾을 수 없음 (SPEC_NOT_FOUND)에 대한 예외 처리 로직
  - 유사한 비즈니스 로직 -> CommentUpdateServiceTest에서만 구현함
    - 댓글 수정/삭제 권한 없음 (COMMENT_ACCESS_DENIED)에 대한 예외 처리 로직
    - 댓글/부모댓글 찾을 수 없음 (COMMENT_NOT_FOUND)에 대한 예외 처리 로직
    - 이미 삭제된 댓글에 대한 수정/삭제 시도 (COMMENT_ALREADY_DELETED)에 대한 예외 처리 로직

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
