### PR TITLE
fix: 레디스에 접속한 채팅방의 정보 (상대 정보)도 추가하여 넣도록 수정

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/adapter/out/dto/ChatSessionRedisValue.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/adapter/out/dto/ChatSessionRedisValue.java
@@ -1,0 +1,7 @@
+package kakaotech.bootcamp.respec.specranking.domain.chat.chat.adapter.out.dto;
+
+public record ChatSessionRedisValue(
+        String privateAddress,
+        Long partnerId
+) {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/handler/ChatWebSocketHandler.java
@@ -9,6 +9,7 @@ import jakarta.validation.Validator;
 import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
+import kakaotech.bootcamp.respec.specranking.domain.chat.chat.adapter.out.dto.ChatSessionRedisValue;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chat.dto.request.SocketChatSendRequest;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chat.manager.WebSocketSessionManager;
 import kakaotech.bootcamp.respec.specranking.global.infrastructure.kafka.dto.ChatProduceDto;
@@ -41,7 +42,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
         Long userId = (Long) session.getAttributes().get("userId");
 
-        redisTemplate.opsForValue().set("chat:user:" + userId, privateAddress, Duration.ofHours(24));
+        ChatSessionRedisValue chatSessionRedisValue = new ChatSessionRedisValue(privateAddress, userId);
+        redisTemplate.opsForValue().set("chat:user:" + userId, chatSessionRedisValue, Duration.ofHours(24));
         webSocketSessionManager.addSession(userId, session);
     }
 


### PR DESCRIPTION
## ☝️ 요약

레디스에 접속한 채팅방의 정보 (상대 정보)도 추가하여 넣도록 수정

## ✏️ 상세 내용

레디스에 접속한 user 정보에 따라 relay 요청, 알림 생성 중 하나를 선택한다.
user가 접속해 있더라도 sender가 보내는 채팅에 접속해 있지 않으면 relay 요청이 아닌 알림을 생성해야한다.
따라서 해당 채팅방의 정보 (접속해 있는 채팅방의 sender 정보)를 redis에 넣어야 consumer가 판단 가능하다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 기능이 정상적으로 동작하는지 확인했습니다.