### PR TITLE
test: comment 도메인의 validator, repository에 대한 테스트코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ out/
 /src/main/resources/application-prod.properties
 /src/main/resources/application-stage.properties
 /src/main/resources/application-test.properties
+/src/test/resources/application-test.properties

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
@@ -47,6 +48,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+    testImplementation 'com.h2database:h2'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,256 @@
+package kakaotech.bootcamp.respec.specranking.domain.social.comment.repository;
+
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentListResponse;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.fixture.RepositoryTestFixture;
+import kakaotech.bootcamp.respec.specranking.global.common.config.QuerydslConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+@ActiveProfiles("test")
+@DisplayName("댓글 Repository 테스트")
+@TestPropertySource(locations = "classpath:application-test.properties")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private User testUser;
+    private User anotherUser;
+    private Spec testSpec;
+
+    @BeforeEach
+    void setUp() {
+        testUser = RepositoryTestFixture.createAndSaveDefaultUser(entityManager);
+        anotherUser = RepositoryTestFixture.createAndSaveAnotherUser(entityManager);
+        testSpec = RepositoryTestFixture.createAndSaveDefaultSpec(entityManager, testUser);
+    }
+
+    @Nested
+    @DisplayName("댓글과 대댓글 조회 테스트")
+    class FindCommentsWithRepliesTest {
+
+        @Test
+        @DisplayName("성공: 삭제되지 않은 댓글과 대댓글 조회")
+        void findCommentsWithReplies_WhenActiveCommentsExist_ShouldReturnCommentsWithReplies() {
+            // given
+            Comment parentComment = RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "부모 댓글", testUser, testSpec, INITIAL_BUNDLE_NUMBER);
+            RepositoryTestFixture.createAndSaveReply(
+                    entityManager, "첫 번째 대댓글", testUser, testSpec, parentComment, INITIAL_BUNDLE_NUMBER);
+            RepositoryTestFixture.createAndSaveReply(
+                    entityManager, "두 번째 대댓글", anotherUser, testSpec, parentComment, INITIAL_BUNDLE_NUMBER);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+
+            CommentListResponse.CommentWithReplies commentWithReplies = result.getContent().getFirst();
+            assertThat(commentWithReplies.commentId()).isEqualTo(parentComment.getId());
+            assertThat(commentWithReplies.content()).isEqualTo("부모 댓글");
+            assertThat(commentWithReplies.replyCount()).isEqualTo(2);
+            assertThat(commentWithReplies.replies()).hasSize(2);
+
+            assertThat(commentWithReplies.replies())
+                    .extracting(CommentListResponse.ReplyInfo::content)
+                    .containsExactly("첫 번째 대댓글", "두 번째 대댓글");
+        }
+
+        @Test
+        @DisplayName("성공: 댓글이 없는 경우 빈 페이지 반환")
+        void findCommentsWithReplies_WhenNoComments_ShouldReturnEmptyPage() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+            assertThat(result.getTotalPages()).isZero();
+        }
+
+        @Test
+        @DisplayName("성공: 삭제된 댓글이지만 삭제되지 않은 대댓글이 있는 경우 조회됨")
+        void findCommentsWithReplies_WhenDeletedCommentHasActiveReplies_ShouldReturnDeletedComment() {
+            // given
+            Comment parentComment = RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "삭제된 부모 댓글", testUser, testSpec, INITIAL_BUNDLE_NUMBER);
+            RepositoryTestFixture.createAndSaveReply(
+                    entityManager, "활성 대댓글", testUser, testSpec, parentComment, INITIAL_BUNDLE_NUMBER);
+
+            parentComment.delete();
+            entityManager.merge(parentComment);
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+
+            CommentListResponse.CommentWithReplies commentWithReplies = result.getContent().getFirst();
+            assertThat(commentWithReplies.commentId()).isEqualTo(parentComment.getId());
+            assertThat(commentWithReplies.replyCount()).isEqualTo(1);
+            assertThat(commentWithReplies.replies()).hasSize(1);
+            assertThat(commentWithReplies.replies().getFirst().content()).isEqualTo("활성 대댓글");
+        }
+
+        @Test
+        @DisplayName("성공: 삭제된 댓글이고 대댓글도 없는 경우 조회되지 않음")
+        void findCommentsWithReplies_WhenDeletedCommentHasNoReplies_ShouldNotReturn() {
+            // given
+            Comment deletedComment = RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "삭제된 댓글", testUser, testSpec, INITIAL_BUNDLE_NUMBER);
+            deletedComment.delete();
+            entityManager.merge(deletedComment);
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공: 페이징 정보가 올바르게 반환됨")
+        void findCommentsWithReplies_WhenPaging_ShouldReturnCorrectPageInfo() {
+            // given
+            for (int i = 1; i <= 5; i++) {
+                RepositoryTestFixture.createAndSaveRootComment(entityManager, "댓글 " + i, testUser, testSpec, i);
+            }
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 3);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(3);
+            assertThat(result.getTotalElements()).isEqualTo(5);
+            assertThat(result.getTotalPages()).isEqualTo(2);
+            assertThat(result.isFirst()).isTrue();
+            assertThat(result.isLast()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 댓글 생성 시간 역순으로 정렬됨")
+        void findCommentsWithReplies_ShouldOrderByCreatedAtDesc() {
+            // given
+            RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "첫 번째 댓글", testUser, testSpec, 1);
+            RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "두 번째 댓글", testUser, testSpec, 2);
+            RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "세 번째 댓글", testUser, testSpec, 3);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(3);
+            assertThat(result.getContent())
+                    .extracting(CommentListResponse.CommentWithReplies::content)
+                    .containsExactly("세 번째 댓글", "두 번째 댓글", "첫 번째 댓글");
+        }
+
+        @Test
+        @DisplayName("성공: 대댓글이 생성 시간 순으로 정렬됨")
+        void findCommentsWithReplies_RepliesShouldOrderByCreatedAtAsc() {
+            // given
+            Comment parentComment = RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "부모 댓글", testUser, testSpec, INITIAL_BUNDLE_NUMBER);
+
+            RepositoryTestFixture.createAndSaveReply(
+                    entityManager, "첫 번째 대댓글", testUser, testSpec, parentComment, INITIAL_BUNDLE_NUMBER);
+            RepositoryTestFixture.createAndSaveReply(
+                    entityManager, "두 번째 대댓글", testUser, testSpec, parentComment, INITIAL_BUNDLE_NUMBER);
+            RepositoryTestFixture.createAndSaveReply(
+                    entityManager, "세 번째 대댓글", testUser, testSpec, parentComment, INITIAL_BUNDLE_NUMBER);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            CommentListResponse.CommentWithReplies commentWithReplies = result.getContent().getFirst();
+
+            assertThat(commentWithReplies.replies())
+                    .extracting(CommentListResponse.ReplyInfo::content)
+                    .containsExactly("첫 번째 대댓글", "두 번째 대댓글", "세 번째 대댓글");
+        }
+
+        @Test
+        @DisplayName("성공: 다른 스펙의 댓글은 조회되지 않음")
+        void findCommentsWithReplies_WhenDifferentSpec_ShouldNotReturnOtherSpecComments() {
+            // given
+            Spec anotherSpec = RepositoryTestFixture.createAndSaveDefaultSpec(entityManager, anotherUser);
+
+            RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "테스트 스펙 댓글", testUser, testSpec, INITIAL_BUNDLE_NUMBER);
+            RepositoryTestFixture.createAndSaveRootComment(
+                    entityManager, "다른 스펙 댓글", testUser, anotherSpec, INITIAL_BUNDLE_NUMBER);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<CommentListResponse.CommentWithReplies> result = commentRepository.findCommentsWithReplies(testSpec.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().content()).isEqualTo("테스트 스펙 댓글");
+        }
+    }
+}

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentQueryValidatorTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentQueryValidatorTest.java
@@ -1,0 +1,57 @@
+package kakaotech.bootcamp.respec.specranking.domain.social.comment.validator;
+
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
+import kakaotech.bootcamp.respec.specranking.fixture.SpecFixture;
+import kakaotech.bootcamp.respec.specranking.global.common.type.SpecStatus;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("댓글 목록 조회 검증 로직 테스트")
+class CommentQueryValidatorTest {
+
+    @Mock
+    private SpecRepository specRepository;
+
+    @InjectMocks
+    private CommentQueryValidator commentQueryValidator;
+
+    @Test
+    @DisplayName("성공: 활성 스펙 존재 검증")
+    void validateSpecExists_WhenActiveSpecExists_ShouldNotThrowException() {
+        // given
+        Spec activeSpec = SpecFixture.createMockSpec();
+        given(specRepository.findByIdAndStatus(DEFAULT_SPEC_ID, SpecStatus.ACTIVE))
+                .willReturn(Optional.of(activeSpec));
+
+        // when & then
+        assertThatCode(() -> commentQueryValidator.validateSpecExists(DEFAULT_SPEC_ID)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("실패: 스펙을 찾을 수 없음")
+    void validateSpecExists_WhenSpecNotFound_ShouldThrowException() {
+        // given
+        given(specRepository.findByIdAndStatus(NON_EXISTENT_SPEC_ID, SpecStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> commentQueryValidator.validateSpecExists(NON_EXISTENT_SPEC_ID))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.SPEC_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentValidatorTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/validator/CommentValidatorTest.java
@@ -1,0 +1,130 @@
+package kakaotech.bootcamp.respec.specranking.domain.social.comment.validator;
+
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.fixture.CommentFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.SpecFixture;
+import kakaotech.bootcamp.respec.specranking.fixture.UserFixture;
+import kakaotech.bootcamp.respec.specranking.global.exception.CustomException;
+import kakaotech.bootcamp.respec.specranking.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("댓글 CUD 기능 검증 로직 테스트")
+class CommentValidatorTest {
+
+    @InjectMocks
+    private CommentValidator commentValidator;
+
+    @Nested
+    @DisplayName("대댓글 생성 검증")
+    class ValidateReplyCreation {
+
+        @Test
+        @DisplayName("성공: 정상적인 대댓글 생성 검증")
+        void validateReplyCreation_WhenValid_ShouldNotThrowException() {
+            // given
+            Spec spec = SpecFixture.createMockSpec();
+            Comment rootComment = CommentFixture.createMockComment();
+
+            given(rootComment.belongsToSpec(spec)).willReturn(true);
+            given(rootComment.isRootComment()).willReturn(true);
+
+            // when & then
+            assertThatCode(() -> commentValidator.validateReplyCreation(rootComment, spec))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패: 부모 댓글이 스펙에 속하지 않음")
+        void validateReplyCreation_WhenCommentSpecMismatch_ShouldThrowException() {
+            // given
+            Spec spec = SpecFixture.createMockSpec();
+            Comment rootComment = CommentFixture.createMockComment();
+
+            given(rootComment.belongsToSpec(spec)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> commentValidator.validateReplyCreation(rootComment, spec))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_SPEC_MISMATCH.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 부모 댓글이 최상위 댓글이 아님")
+        void validateReplyCreation_WhenReplyDepthExceeded_ShouldThrowException() {
+            // given
+            Spec spec = SpecFixture.createMockSpec();
+            Comment rootComment = CommentFixture.createMockComment();
+
+            given(rootComment.belongsToSpec(spec)).willReturn(true);
+            given(rootComment.isRootComment()).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> commentValidator.validateReplyCreation(rootComment, spec))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.REPLY_DEPTH_EXCEEDED.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 수정/삭제 검증")
+    class ValidateCommentUpdateAndDeletion {
+
+        @Test
+        @DisplayName("성공: 정상적인 댓글 수정/삭제 검증")
+        void validateCommentUpdateAndDeletion_WhenValid_ShouldNotThrowException() {
+            // given
+            User user = UserFixture.createMockUser();
+            Comment comment = CommentFixture.createMockComment();
+
+            given(comment.isWrittenBy(user)).willReturn(true);
+            given(comment.isDeleted()).willReturn(false);
+
+            // when & then
+            assertThatCode(() -> commentValidator.validateCommentUpdate(comment, user))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패: 댓글 수정/삭제 권한 없음")
+        void validateCommentUpdateAndDeletion_WhenCommentAccessDenied_ShouldThrowException() {
+            // given
+            User user = UserFixture.createMockUser();
+            Comment comment = CommentFixture.createMockComment();
+
+            given(comment.isWrittenBy(user)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> commentValidator.validateCommentUpdate(comment, user))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_ACCESS_DENIED.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 삭제된 댓글을 수정/삭제 시도함")
+        void validateCommentUpdateAndDeletion_WhenCommentAlreadyDeleted_ShouldThrowException() {
+            // given
+            User user = UserFixture.createMockUser();
+            Comment comment = CommentFixture.createMockComment();
+
+            given(comment.isWrittenBy(user)).willReturn(true);
+            given(comment.isDeleted()).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> commentValidator.validateCommentUpdate(comment, user))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.COMMENT_ALREADY_DELETED.getMessage());
+        }
+    }
+}

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/RepositoryTestFixture.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/RepositoryTestFixture.java
@@ -1,0 +1,78 @@
+package kakaotech.bootcamp.respec.specranking.fixture;
+
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+
+public class RepositoryTestFixture {
+
+    public static User createAndSaveUser(TestEntityManager entityManager, String loginId, String nickname) {
+        User user = new User(
+                loginId,
+                "encoded_password_" + loginId,
+                nickname,
+                "https://example.com/profile/" + loginId + ".jpg",
+                true
+        );
+        return entityManager.persistAndFlush(user);
+    }
+
+    public static User createAndSaveDefaultUser(TestEntityManager entityManager) {
+        return createAndSaveUser(entityManager, DEFAULT_USER_LOGIN_ID, DEFAULT_USER_NICKNAME);
+    }
+
+    public static User createAndSaveAnotherUser(TestEntityManager entityManager) {
+        return createAndSaveUser(entityManager, ANOTHER_USER_LOGIN_ID, ANOTHER_USER_NICKNAME);
+    }
+
+    public static Spec createAndSaveSpec(TestEntityManager entityManager, User user, String assessment) {
+        Spec spec = new Spec(
+                user,
+                JobField.INTERNET_IT,
+                DEFAULT_EDUCATION_SCORE,
+                DEFAULT_WORK_EXPERIENCE_SCORE,
+                DEFAULT_ACTIVITY_NETWORKING_SCORE,
+                DEFAULT_CERTIFICATION_SCORE,
+                DEFAULT_ENGLISH_SKILL_SCORE,
+                DEFAULT_TOTAL_ANALYSIS_SCORE,
+                assessment
+        );
+        return entityManager.persistAndFlush(spec);
+    }
+
+    public static Spec createAndSaveDefaultSpec(TestEntityManager entityManager, User user) {
+        return createAndSaveSpec(entityManager, user, DEFAULT_ASSESSMENT);
+    }
+
+    public static Comment createAndSaveRootComment(TestEntityManager entityManager,
+                                                   String content, User writer, Spec spec, int bundle) {
+        Comment comment = new Comment(
+                spec,
+                writer,
+                null,
+                content,
+                bundle,
+                ROOT_COMMENT_DEPTH
+        );
+        return entityManager.persistAndFlush(comment);
+    }
+
+    public static Comment createAndSaveReply(TestEntityManager entityManager, String content,
+                                             User writer, Spec spec, Comment parentComment, int bundle) {
+        Comment reply = new Comment(
+                spec,
+                writer,
+                parentComment,
+                content,
+                bundle,
+                REPLY_DEPTH
+        );
+        return entityManager.persistAndFlush(reply);
+    }
+
+    private RepositoryTestFixture() { }
+}

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/TestConstants.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/TestConstants.java
@@ -3,15 +3,25 @@ package kakaotech.bootcamp.respec.specranking.fixture;
 public class TestConstants {
 
     public static final Long DEFAULT_USER_ID = 1L;
+    public static final String DEFAULT_USER_LOGIN_ID = "testuser";
     public static final String DEFAULT_USER_NICKNAME = "테스트유저";
     public static final String DEFAULT_USER_PROFILE_URL = "https://example.com/profile.jpg";
 
     public static final Long ANOTHER_USER_ID = 2L;
+    public static final String ANOTHER_USER_LOGIN_ID = "anotheruser";
     public static final String ANOTHER_USER_NICKNAME = "다른유저";
     public static final String ANOTHER_USER_PROFILE_URL = "https://example.com/another-profile.jpg";
 
     public static final Long DEFAULT_SPEC_ID = 1L;
     public static final Long NON_EXISTENT_SPEC_ID = 999L;
+
+    public static final Double DEFAULT_EDUCATION_SCORE = 85.0;
+    public static final Double DEFAULT_WORK_EXPERIENCE_SCORE = 75.0;
+    public static final Double DEFAULT_ACTIVITY_NETWORKING_SCORE = 80.0;
+    public static final Double DEFAULT_CERTIFICATION_SCORE = 70.0;
+    public static final Double DEFAULT_ENGLISH_SKILL_SCORE = 65.0;
+    public static final Double DEFAULT_TOTAL_ANALYSIS_SCORE = 70.0;
+    public static final String DEFAULT_ASSESSMENT = "우수한 개발 역량을 보유하고 있습니다.";
 
     public static final Long DEFAULT_COMMENT_ID = 2L;
     public static final Long DEFAULT_PARENT_COMMENT_ID = 3L;

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=VALUE
+spring.datasource.driver-class-name=org.h2.Driver
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+spring.test.database.replace=NONE

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,8 +1,0 @@
-spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=VALUE
-spring.datasource.driver-class-name=org.h2.Driver
-
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-
-spring.test.database.replace=NONE


### PR DESCRIPTION
## ☝️ 요약
comment 도메인의 validator, repository에 대한 테스트코드 작성

<br/>

## ✏️ 상세 내용
- ⭐️⭐️⭐️ `build.gradle`에 코드를 추가했기 때문에 동기화 후 실행해야 정상 작동합니다.

- Validator 테스트코드
  - Comment 도메인의 validator 메소드들에 대한 테스트 코드 작성
  - Service단에서는 mockValidator를 주입했기 때문에 따로 검증이 필요하다. 예외 처리 부분도 많이 포함되어 있어 중요하다.
  - `CommentQueryValidatorTest` : 2개 테스트 통과
  - `CommentValidatorTest` : 6개 테스트 통과
    
    - 중복되는 테스트 코드는 한 번만 작성함
    - `validateReplyCreation` : 대댓글 생성 검증 성공, COMMENT_SPEC_MISMATCH, REPLY_DEPTH_EXCEEDED
    - `validateCommentUpdateAndDeletion` : 댓글 수정 검증 성공, COMMENT_ACCESS_DENIED, COMMENT_ALREADY_DELETED

- Repository 테스트코드
  - `findCommentsWithReplies` 메소드는 직접 작성한 QueryDSL 활용 메소드이기 때문에 테스트코드 작성이 필요하다.
  - `fixture/TestConstants` : 필요한 상수 추가 선언
  - `fixture/RepositoryTestFixture` : mock user/spec/comment 간단히 생성할 수 있도록 하는 클래스
  - `CommentRepositoryTest` : 8개 테스트 통과
    
    - 성공: 삭제되지 않은 댓글과 대댓글 조회
    - 성공: 댓글이 없는 경우 빈 페이지 반환
    - 성공: 삭제된 댓글이지만 삭제되지 않은 대댓글이 있는 경우 조회됨
    - 성공: 삭제된 댓글이고 대댓글도 없는 경우 조회되지 않음
    - 성공: 페이징 정보가 올바르게 반환됨
    - 성공: 댓글 생성 시간 역순으로 정렬됨
    - 성공: 대댓글이 생성 시간 순으로 정렬됨
    - 성공: 다른 스펙의 댓글은 조회되지 않음
  - `build.gradle` : h2 db 관련 의존성 추가

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 환경에서 서비스가 정상적으로 작동하는지 확인했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
  - `resources/application-test.properties` : 설정 파일이고 jelly와 설정이 달라 ignore 추가하기로 결정함
  - Comment 도메인 테스트 커버리지 현황 : 클래스 기준 88%, 메서드 기준 85%, 줄 기준 94%, 브랜치 기준 82%
 