### PR TITLE
feat: getRankings 쿼리 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly "io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-aarch_64"
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/controller/SpecQueryController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/controller/SpecQueryController.java
@@ -7,6 +7,7 @@ import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.response.SpecM
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.response.SpecMetaResponse.Meta;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.service.SpecDetailQueryService;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.service.SpecQueryService;
+import kakaotech.bootcamp.respec.specranking.global.common.aop.timetrace.TimeTrace;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,7 @@ public class SpecQueryController {
     private final SpecDetailQueryService specDetailQueryService;
 
     @GetMapping(params = "type=ranking")
+    @TimeTrace
     public RankingResponse getRankings(
             @RequestParam(value = "jobField") JobField jobField,
             @RequestParam(value = "cursor", required = false) String cursor,

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/entity/Spec.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/entity/Spec.java
@@ -25,8 +25,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-        @Index(name = "idx_job_field_total_analysis_score", columnList = "job_field, total_analysis_score"),
-        @Index(name = "idx_total_analysis_score", columnList = "total_analysis_score")
+        @Index(name = "idx_status_job_field_total_analysis_score", columnList = "status, job_field, total_analysis_score"),
+        @Index(name = "idx_status_total_analysis_score", columnList = "status, total_analysis_score")
 })
 public class Spec extends BaseTimeEntity {
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/repository/SpecRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/repository/SpecRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
 import kakaotech.bootcamp.respec.specranking.global.common.type.SpecStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SpecRepository extends JpaRepository<Spec, Long>, SpecRepositoryCustom {
     Long countByStatus(SpecStatus status);
@@ -11,4 +12,7 @@ public interface SpecRepository extends JpaRepository<Spec, Long>, SpecRepositor
     Optional<Spec> findByUserIdAndStatus(Long userId, SpecStatus status);
 
     Optional<Spec> findByIdAndStatus(Long id, SpecStatus status);
+
+    @Query("SELECT COUNT(DISTINCT s.user.id) FROM Spec s")
+    long countDistinctUsersHavingSpec();
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -85,6 +85,7 @@ public class SpecQueryService {
             }
 
             String nextCursor = hasNext ? encodeCursor(specs.getLast().getId()) : null;
+            long countUsersHavingSpec = userRepository.countUsersHavingSpec();
 
             List<RankingResponse.RankingItem> rankingItems = specs.stream().map(spec -> {
                 User user = spec.getUser();
@@ -94,7 +95,7 @@ public class SpecQueryService {
                         user.getId(), user.getNickname(), user.getUserProfileUrl(), spec.getId(),
                         spec.getTotalAnalysisScore(),
                         specRepository.findAbsoluteRankByJobField(JobField.TOTAL, spec.getId()),
-                        userRepository.countUsersHavingSpec(),
+                        countUsersHavingSpec,
                         specJobField,
                         specRepository.findAbsoluteRankByJobField(specJobField, spec.getId()),
                         specRepository.countByJobField(specJobField),

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -85,7 +85,8 @@ public class SpecQueryService {
             }
 
             String nextCursor = hasNext ? encodeCursor(specs.getLast().getId()) : null;
-            long countUsersHavingSpec = userRepository.countUsersHavingSpec();
+
+            long countUsersHavingSpec = specRepository.countDistinctUsersHavingSpec();
 
             List<RankingResponse.RankingItem> rankingItems = specs.stream().map(spec -> {
                 User user = spec.getUser();

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/aop/timetrace/TimeTrace.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/aop/timetrace/TimeTrace.java
@@ -1,0 +1,11 @@
+package kakaotech.bootcamp.respec.specranking.global.common.aop.timetrace;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeTrace {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/aop/timetrace/TimeTraceAspect.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/aop/timetrace/TimeTraceAspect.java
@@ -26,8 +26,8 @@ public class TimeTraceAspect {
             return joinPoint.proceed();
         } finally {
             stopWatch.stop();
-            log.info("{} - Total time = {}s", joinPoint.getSignature().toShortString(),
-                    stopWatch.getTotalTimeSeconds());
+            log.info("{} - Total time = {}ms", joinPoint.getSignature().toShortString(),
+                    stopWatch.getTotalTimeMillis());
         }
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/aop/timetrace/TimeTraceAspect.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/aop/timetrace/TimeTraceAspect.java
@@ -1,0 +1,33 @@
+package kakaotech.bootcamp.respec.specranking.global.common.aop.timetrace;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Slf4j
+@Component
+@Aspect
+public class TimeTraceAspect {
+
+    @Pointcut("@annotation(kakaotech.bootcamp.respec.specranking.global.common.aop.timetrace.TimeTrace)")
+    private void timeTracePointcut() {
+    }
+
+    @Around("timeTracePointcut()")
+    public Object traceTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+
+        try {
+            stopWatch.start();
+            return joinPoint.proceed();
+        } finally {
+            stopWatch.stop();
+            log.info("{} - Total time = {}s", joinPoint.getSignature().toShortString(),
+                    stopWatch.getTotalTimeSeconds());
+        }
+    }
+}


### PR DESCRIPTION
## ☝️ 요약

getRankings 메서드를 쿼리 성능 개선한다.

## ✏️ 상세 내용

1. countUsersHavingSpec의 경우 호출 시 공통된 값을 가져옵니다. 이를 공통으로 분리하여 중복된 쿼리를 제거합니다.
평균 1200ms -> 200ms로 개선

2. 스펙이 존재하는 유저 수를 유저테이블에서 스펙 테이블을 조인하고 찾아내는 구조였습니다.
이를 스펙 테이블을 기준으로 distinct 유저를 사용하도록 변경합니다.
이렇게 진행하면 조인을 하지 않으므로 성능이 개선됩니다.
평균 200ms -> 120ms 개선되었습니다.

총 1200ms -> 120ms로 개선, 캐싱이 아닌 쿼리만으로 90% 개선 완료.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 정상적으로 동작하는지 확인했습니다.