### PR TITLE
feat: Cached jitter를 이용한 선제적 갱신, 논문 내용의 PER 알고리즘으로 고도화

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/cache/CachedMetaResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/cache/CachedMetaResponse.java
@@ -1,0 +1,12 @@
+package kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache;
+
+public record CachedMetaResponse(
+        long computeTime,
+        CachedMeta data
+) {
+    public record CachedMeta(
+            Long totalUserCount,
+            double averageScore
+    ) {
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/cache/CachedRankingResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/cache/CachedRankingResponse.java
@@ -7,7 +7,9 @@ import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 public record CachedRankingResponse(
         List<CachedRankingItem> items,
         boolean hasNext,
-        String nextCursor) {
+        String nextCursor,
+        long computeTime
+) {
 
     public record CachedRankingItem(
             Long userId,

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -1,7 +1,5 @@
 package kakaotech.bootcamp.respec.specranking.domain.spec.spec.service;
 
-import static kakaotech.bootcamp.respec.specranking.global.infrastructure.redis.constant.CacheManagerConstant.SPEC_META_DATA_CACHING_SECONDS;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -10,6 +8,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.repository.BookmarkRepository;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedMetaResponse;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedMetaResponse.CachedMeta;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedRankingResponse;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.response.RankingResponse;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.response.SearchResponse;
@@ -170,20 +170,24 @@ public class SpecQueryService {
 
     public Meta getMetaData(JobField jobField) {
         String cacheKey = "specMetadata::" + jobField.name();
-        Meta cached = (Meta) redisTemplate.opsForValue().get("specMetadata::" + jobField.name());
-        int randomDivisor = 18 + (int) (Math.random() * 5);
+        CachedMetaResponse cached = (CachedMetaResponse) redisTemplate.opsForValue()
+                .get("specMetadata::" + jobField.name());
 
         if (cached != null) {
             Long ttl = redisTemplate.getExpire(cacheKey, TimeUnit.SECONDS);
-            if (ttl != null && ttl <= SPEC_META_DATA_CACHING_SECONDS / randomDivisor) {
+            if (ttl != null && shouldRefreshByPER(ttl, cached.computeTime(), 1.0)) {
                 specCacheRefreshService.refreshSpecMetadata(jobField);
             }
-            return cached;
         }
 
-        Meta meta = specRefreshQueryService.getMetaDataFromDb(jobField);
-        redisTemplate.opsForValue().set(cacheKey, meta, Duration.ofHours(1));
-        return meta;
+        if (cached == null) {
+            cached = specRefreshQueryService.getMetaDataFromDb(jobField);
+            redisTemplate.opsForValue().set(cacheKey, cached, Duration.ofHours(1));
+        }
+
+        CachedMeta data = cached.data();
+
+        return new Meta(data.totalUserCount(), data.averageScore());
     }
 
     private String encodeCursor(Long id) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -204,10 +204,11 @@ public class SpecQueryService {
         return Long.parseLong(decodedString);
     }
 
-    private boolean shouldRefreshByPER(Long ttl, double cacheComputeTime, double beta) {
+    private boolean shouldRefreshByPER(long ttl, long cacheComputeTime, double beta) {
+        long remainedTtlMillis = TimeUnit.SECONDS.toMillis(ttl);
         double currentTime = System.currentTimeMillis();
         double randomNaturalLog = Math.log(Math.random());
-        double expireTime = ttl + currentTime;
+        double expireTime = currentTime + remainedTtlMillis;
 
         return currentTime - cacheComputeTime * beta * randomNaturalLog >= expireTime;
     }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/cache/SpecCacheRefreshService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/cache/SpecCacheRefreshService.java
@@ -1,8 +1,8 @@
 package kakaotech.bootcamp.respec.specranking.domain.spec.spec.service.cache;
 
 import java.time.Duration;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedMetaResponse;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedRankingResponse;
-import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.response.SpecMetaResponse.Meta;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.service.refresh.SpecRefreshQueryService;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +19,8 @@ public class SpecCacheRefreshService {
 
     @Async
     public void refreshSpecMetadata(JobField jobField) {
-        Meta meta = specRefreshQueryService.getMetaDataFromDb(jobField);
-        redisTemplate.opsForValue().set("specMetadata::" + jobField.name(), meta, Duration.ofHours(1));
+        CachedMetaResponse cachedMetaResponse = specRefreshQueryService.getMetaDataFromDb(jobField);
+        redisTemplate.opsForValue().set("specMetadata::" + jobField.name(), cachedMetaResponse, Duration.ofHours(1));
     }
 
     @Async

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
@@ -62,13 +62,14 @@ public class SpecRefreshQueryService {
             nextCursor = encodeCursor(specs.getLast().getId());
         }
 
+        Long totalUserCount = userRepository.countUsersHavingSpec();
+
         List<CachedRankingResponse.CachedRankingItem> items = specs.stream().map(spec -> {
             User user = spec.getUser();
             JobField specJobField = spec.getJobField();
 
             Long totalRank = specRepository.findAbsoluteRankByJobField(JobField.TOTAL, spec.getId());
             Long jobFieldRank = specRepository.findAbsoluteRankByJobField(specJobField, spec.getId());
-            Long totalUserCount = userRepository.countUsersHavingSpec();
             Long usersCountByJobField = specRepository.countByJobField(specJobField);
             Long commentsCount = commentRepository.countBySpecId(spec.getId());
             Long bookmarksCount = bookmarkRepository.countBySpecId(spec.getId());

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
@@ -4,8 +4,9 @@ import java.util.Base64;
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.social.bookmark.repository.BookmarkRepository;
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedMetaResponse;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedMetaResponse.CachedMeta;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.cache.CachedRankingResponse;
-import kakaotech.bootcamp.respec.specranking.domain.spec.spec.dto.response.SpecMetaResponse.Meta;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
 import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
@@ -25,7 +26,8 @@ public class SpecRefreshQueryService {
     private final CommentRepository commentRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public Meta getMetaDataFromDb(JobField jobField) {
+    public CachedMetaResponse getMetaDataFromDb(JobField jobField) {
+        long startTime = System.currentTimeMillis();
         long totalUserCount = 0;
         Double averageScore = 0.0;
 
@@ -41,9 +43,9 @@ public class SpecRefreshQueryService {
             averageScore = 0.0;
         }
 
-        Meta meta = new Meta(totalUserCount, averageScore);
-
-        return meta;
+        long endTime = System.currentTimeMillis();
+        CachedMeta cachedMeta = new CachedMeta(totalUserCount, averageScore);
+        return new CachedMetaResponse(endTime - startTime, cachedMeta);
     }
 
     public CachedRankingResponse getRankingDataFromDb(JobField jobField, int limit) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
@@ -47,6 +47,7 @@ public class SpecRefreshQueryService {
     }
 
     public CachedRankingResponse getRankingDataFromDb(JobField jobField, int limit) {
+        long startTime = System.currentTimeMillis();
         List<Spec> specs = specRepository.findTopSpecsByJobFieldWithCursor(jobField, Long.MAX_VALUE, limit + 1);
 
         boolean hasNext = specs.size() > limit;
@@ -86,7 +87,8 @@ public class SpecRefreshQueryService {
             );
         }).toList();
 
-        return new CachedRankingResponse(items, hasNext, nextCursor);
+        long endTime = System.currentTimeMillis();
+        return new CachedRankingResponse(items, hasNext, nextCursor, (endTime - startTime));
     }
 
     private String encodeCursor(Long id) {


### PR DESCRIPTION
## ☝️ 요약

선제적 갱신을 PER 알고리즘으로 고도화 합니다.

## ✏️ 상세 내용

전의 캐싱의 경우 단순 jitter를 적용한 선제적 갱신이었습니다.

이를 선제적 갱신에서 효과적인 알고리즘으로 알려진 PER 알고리즘으로 전환합니다.

beta와 같은 파라미터로 선제적 갱신을 얼마나 자주 적용할지 선택할 수 있습니다.

또한 캐시를 계산하기 위해 걸린 "계산 시간"을 기반으로 확률적으로 캐싱 refresh을 적용하여 효율적인 선제적 갱신이 가능합니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 코드가 정상적으로 동작하는 것을 확인했습니다.