### PR TITLE
fix(getRankings): 프론트에서 상태관리하는 isBookmarked 필드를 제거한다.

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/response/RankingResponse.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/dto/response/RankingResponse.java
@@ -38,7 +38,6 @@ public record RankingResponse(
             JobField jobField,
             Long rankByJobField,
             Long usersCountByJobField,
-            Boolean isBookmarked,
             Long commentsCount,
             Long bookmarksCount
     ) {

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/SpecQueryService.java
@@ -41,11 +41,6 @@ public class SpecQueryService {
     private final SpecRefreshQueryService specRefreshQueryService;
 
     public RankingResponse getRankings(JobField jobField, String cursor, int limit) {
-        Optional<Long> userIdOpt = UserUtils.getCurrentUserId();
-        List<Long> bookmarkedSpecIds = userIdOpt
-                .map(bookmarkRepository::findSpecIdsByUserId)
-                .orElseGet(ArrayList::new);
-
         if (cursor == null) {
             String cacheKey = "rankings::" + jobField.name() + "::" + limit;
             CachedRankingResponse cached = (CachedRankingResponse) redisTemplate.opsForValue().get(cacheKey);
@@ -67,7 +62,6 @@ public class SpecQueryService {
                             i.userId(), i.nickname(), i.profileImageUrl(), i.specId(),
                             i.score(), i.totalRank(), i.totalUsersCount(),
                             i.jobField(), i.rankByJobField(), i.usersCountByJobField(),
-                            bookmarkedSpecIds.contains(i.specId()),
                             i.commentsCount(), i.bookmarksCount()
                     ))
                     .toList();
@@ -99,7 +93,6 @@ public class SpecQueryService {
                         specJobField,
                         specRepository.findAbsoluteRankByJobField(specJobField, spec.getId()),
                         specRepository.countByJobField(specJobField),
-                        bookmarkedSpecIds.contains(spec.getId()),
                         commentRepository.countBySpecId(spec.getId()),
                         bookmarkRepository.countBySpecId(spec.getId())
                 );


### PR DESCRIPTION
## ☝️ 요약

프론트에서 상태관리하는 isBookmarked 필드를 제거한다.

## ✏️ 상세 내용

프론트에서 로그인할때 자신의 즐겨찾기 목록을 가져온다.

따라서 getRankings에서 즐겨찾기 목록을 "계속해서 api 호출할 필요가 없다."

즉 프론트에서 상태관리를 한다면 로그인 할때에만 db에서 즐겨찾기 목록을 가져오고, 그뒤로는 bookmark에 대한 db 접근을 하지 않는다.

따라서 isBookmarked 필드를 제거한다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] postman으로 정상적으로 호출되는지 확인했습니다.