### PR TITLE
feat: groupBy 절을 이용해 10개의 페이지네이션 한번에 count 조회

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/repository/SpecRepositoryCustom.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/repository/SpecRepositoryCustom.java
@@ -1,5 +1,6 @@
 package kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository;
 
+import com.querydsl.core.Tuple;
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
@@ -15,4 +16,6 @@ public interface SpecRepositoryCustom {
     Long findAbsoluteRankByJobField(JobField jobField, Long specId);
 
     Double findAverageScoreByJobField(JobField jobField);
+
+    List<Tuple> countByJobFields(List<JobField> jobFields);
 }


### PR DESCRIPTION
## ☝️ 요약

groupBy 절을 이용해 10개의 페이지네이션 한번에 count 조회

## ✏️ 상세 내용

RankingBoard는 커서 기반 페이지 네이션으로 10개씩 스펙에 관련된 필드를 가져오게 됩니다. 이를 group by 절을 활용해 한번에 가져오도록 개선하여 22.6% 성능 개선 하였습니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 코드가 정상적으로 동작합니다.
