### PR TITLE
test: Comment 도메인 integration 테스트코드 작성

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/exception/GlobalExceptionHandler.java
@@ -8,10 +8,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+@ControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/CommentIntegrationTest.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/domain/social/comment/CommentIntegrationTest.java
@@ -1,4 +1,400 @@
 package kakaotech.bootcamp.respec.specranking.domain.social.comment;
 
-public class CommentIntegrationTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kakaotech.bootcamp.respec.specranking.domain.auth.dto.AuthenticatedUserDto;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.constants.CommentMessages;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.dto.CommentRequest;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
+import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
+import kakaotech.bootcamp.respec.specranking.fixture.RepositoryTestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static kakaotech.bootcamp.respec.specranking.fixture.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"server.private-address=localhost"})
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Comment 통합 테스트")
+class CommentIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SpecRepository specRepository;
+
+    private User testUser;
+    private Spec testSpec;
+    private Comment parentComment;
+
+    @BeforeEach
+    void setUp() {
+        testUser = RepositoryTestFixture.createAndSaveDefaultUserForIntegration(userRepository);
+        testSpec = RepositoryTestFixture.createAndSaveDefaultSpecForIntegration(specRepository, testUser);
+        parentComment = RepositoryTestFixture.createAndSaveRootCommentForIntegration(
+                commentRepository, FIRST_COMMENT_CONTENT, testUser,
+                testSpec, INITIAL_BUNDLE_NUMBER
+        );
+    }
+
+    @Nested
+    @DisplayName("댓글 작성 통합 테스트")
+    class CommentCreateIntegrationTest {
+
+        @Test
+        @DisplayName("성공: 새로운 댓글 생성")
+        void createComment_Success() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest(DEFAULT_COMMENT_CONTENT);
+
+            // when & then
+            mockMvc.perform(post(COMMENT_API_URL, testSpec.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.message").value(CommentMessages.COMMENT_CREATE_SUCCESS))
+                    .andExpect(jsonPath("$.data.content").value(DEFAULT_COMMENT_CONTENT))
+                    .andExpect(jsonPath("$.data.depth").value(ROOT_COMMENT_DEPTH))
+                    .andExpect(jsonPath("$.data.parentCommentId").isEmpty());
+
+            // DB check
+            List<Comment> comments = commentRepository.findAll();
+            assertThat(comments).hasSize(2);
+
+            Comment newComment = comments.getLast();
+
+            assertThat(newComment.getContent()).isEqualTo(DEFAULT_COMMENT_CONTENT);
+            assertThat(newComment.getDepth()).isEqualTo(ROOT_COMMENT_DEPTH);
+            assertThat(newComment.getParentComment()).isNull();
+            assertThat(newComment.getWriter()).isEqualTo(testUser);
+            assertThat(newComment.getSpec()).isEqualTo(testSpec);
+            assertThat(newComment.isDeleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 스펙에 댓글 생성")
+        void createComment_WithNonExistentSpec_ShouldFail() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest(DEFAULT_COMMENT_CONTENT);
+
+            // when & then
+            mockMvc.perform(post(COMMENT_API_URL, NON_EXISTENT_SPEC_ID)
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 댓글 내용")
+        void createComment_WithInvalidContent_ShouldFail() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest("");
+
+            // when & then
+            mockMvc.perform(post(COMMENT_API_URL, testSpec.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("대댓글 작성 통합 테스트")
+    class ReplyCreateIntegrationTest {
+
+        @Test
+        @DisplayName("성공: 새로운 대댓글 생성")
+        void createReply_Success() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest(REPLY_CONTENT);
+
+            // when & then
+            mockMvc.perform(post(COMMENT_API_URL + "/{commentId}/replies", testSpec.getId(), parentComment.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.message").value(CommentMessages.REPLY_CREATE_SUCCESS))
+                    .andExpect(jsonPath("$.data.content").value(REPLY_CONTENT))
+                    .andExpect(jsonPath("$.data.depth").value(REPLY_DEPTH))
+                    .andExpect(jsonPath("$.data.parentCommentId").value(parentComment.getId()));
+
+            // DB check
+            List<Comment> comments = commentRepository.findAll();
+            assertThat(comments).hasSize(2);
+
+            Comment newReply = comments.getLast();
+
+            assertThat(newReply.getContent()).isEqualTo(REPLY_CONTENT);
+            assertThat(newReply.getDepth()).isEqualTo(REPLY_DEPTH);
+            assertThat(newReply.getParentComment()).isEqualTo(parentComment);
+            assertThat(newReply.getWriter()).isEqualTo(testUser);
+            assertThat(newReply.getSpec()).isEqualTo(testSpec);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 부모 댓글에 대댓글 생성")
+        void createReply_WithNonExistentParentComment_ShouldFail() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest(REPLY_CONTENT);
+
+            // when & then
+            mockMvc.perform(post(COMMENT_API_URL + "/{commentId}/replies", testSpec.getId(), NON_EXISTENT_PARENT_COMMENT_ID)
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 수정 통합 테스트")
+    class CommentUpdateIntegrationTest {
+
+        @Test
+        @DisplayName("성공: 댓글 수정")
+        void updateComment_Success() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest(UPDATED_COMMENT_CONTENT);
+
+            // when & then
+            mockMvc.perform(patch(COMMENT_API_URL + "/{commentId}", testSpec.getId(), parentComment.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.message").value(CommentMessages.COMMENT_UPDATE_SUCCESS))
+                    .andExpect(jsonPath("$.data.content").value(UPDATED_COMMENT_CONTENT));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 댓글 수정")
+        void updateComment_WithNonExistentComment_ShouldFail() throws Exception {
+            // given
+            CommentRequest request = new CommentRequest(UPDATED_COMMENT_CONTENT);
+
+            // when & then
+            mockMvc.perform(patch(COMMENT_API_URL + "/{commentId}", testSpec.getId(), NON_EXISTENT_COMMENT_ID)
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 삭제 통합 테스트")
+    class CommentDeleteIntegrationTest {
+
+        @Test
+        @DisplayName("성공: 대댓글이 있는 댓글 삭제")
+        void deleteComment_Success() throws Exception {
+            // when & then
+            mockMvc.perform(delete(COMMENT_API_URL + "/{commentId}", testSpec.getId(), parentComment.getId())
+                            .with(authentication(createAuthentication(testUser.getId()))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.message").value(CommentMessages.COMMENT_DELETE_SUCCESS));
+
+            // DB check
+            Comment deletedComment = commentRepository.findById(parentComment.getId()).orElseThrow();
+            assertThat(deletedComment.isDeleted()).isTrue();
+            assertThat(deletedComment.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 댓글 삭제")
+        void deleteComment_WithNonExistentComment_ShouldFail() throws Exception {
+            // when & then
+            mockMvc.perform(delete(COMMENT_API_URL + "/{commentId}", testSpec.getId(), NON_EXISTENT_COMMENT_ID)
+                            .with(authentication(createAuthentication(testUser.getId()))))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 목록 조회 통합 테스트")
+    class GetCommentsIntegrationTest {
+
+        @Test
+        @DisplayName("성공: 댓글 및 대댓글 목록 조회")
+        void getComments_WithCommentsAndReplies_Success() throws Exception {
+            // given
+            Comment reply1 = RepositoryTestFixture.createAndSaveReplyForIntegration(
+                    commentRepository, "첫 번째 대댓글", testUser, testSpec,
+                    parentComment, INITIAL_BUNDLE_NUMBER
+            );
+            Comment reply2 = RepositoryTestFixture.createAndSaveReplyForIntegration(
+                    commentRepository, "두 번째 대댓글", testUser, testSpec,
+                    parentComment, INITIAL_BUNDLE_NUMBER
+            );
+
+            // when & then
+            mockMvc.perform(get(COMMENT_API_URL, testSpec.getId())
+                            .param("page", "0")
+                            .param("size", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.data.comments").isArray())
+                    .andExpect(jsonPath("$.data.comments[0].content").value(FIRST_COMMENT_CONTENT))
+                    .andExpect(jsonPath("$.data.comments[0].replyCount").value(2))
+                    .andExpect(jsonPath("$.data.comments[0].replies").isArray())
+                    .andExpect(jsonPath("$.data.comments[0].replies[0].content").value("첫 번째 대댓글"))
+                    .andExpect(jsonPath("$.data.comments[0].replies[1].content").value("두 번째 대댓글"))
+                    .andExpect(jsonPath("$.data.pageInfo.totalElements").value(3))
+                    .andExpect(jsonPath("$.data.pageInfo.pageNumber").value(0))
+                    .andExpect(jsonPath("$.data.pageInfo.pageSize").value(10));
+        }
+
+        @Test
+        @DisplayName("성공: 빈 댓글 목록 조회")
+        void getComments_WithEmptyComments_Success() throws Exception {
+            // given
+            commentRepository.deleteAll();
+
+            // when & then
+            mockMvc.perform(get(COMMENT_API_URL, testSpec.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.data.comments").isArray())
+                    .andExpect(jsonPath("$.data.comments").isEmpty())
+                    .andExpect(jsonPath("$.data.pageInfo.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("성공: 페이지네이션 테스트")
+        void getComments_WithPagination_Success() throws Exception {
+            // given
+            for (int i = 1; i <= 5; i++) {
+                RepositoryTestFixture.createAndSaveRootCommentForIntegration(
+                        commentRepository, "댓글 " + i, testUser, testSpec, i
+                );
+            }
+
+            // when & then
+            mockMvc.perform(get(COMMENT_API_URL, testSpec.getId())
+                            .param("page", "0")
+                            .param("size", "3"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.comments").isArray())
+                    .andExpect(jsonPath("$.data.comments.length()").value(3))
+                    .andExpect(jsonPath("$.data.pageInfo.totalElements").value(6))
+                    .andExpect(jsonPath("$.data.pageInfo.totalPages").value(2))
+                    .andExpect(jsonPath("$.data.pageInfo.isFirst").value(true))
+                    .andExpect(jsonPath("$.data.pageInfo.isLast").value(false));
+
+            mockMvc.perform(get(COMMENT_API_URL, testSpec.getId())
+                            .param("page", "1")
+                            .param("size", "3"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.comments.length()").value(3))
+                    .andExpect(jsonPath("$.data.pageInfo.isFirst").value(false))
+                    .andExpect(jsonPath("$.data.pageInfo.isLast").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 플로우 통합 테스트")
+    class FullFlowIntegrationTest {
+
+        @Test
+        @DisplayName("성공: 댓글 생성 -> 대댓글 생성 -> 조회 -> 수정 -> 삭제 플로우")
+        void fullCommentFlow_Success() throws Exception {
+            // 1. create new comment
+            CommentRequest createRequest = new CommentRequest("통합테스트 댓글");
+
+            mockMvc.perform(post(COMMENT_API_URL, testSpec.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(createRequest)))
+                    .andExpect(status().isCreated());
+
+            // 2. find new comment
+            Comment newComment = commentRepository.findAll().getFirst();
+
+            // 3. create reply
+            CommentRequest replyRequest = new CommentRequest("통합테스트 대댓글");
+
+            mockMvc.perform(post(COMMENT_API_URL + "/{commentId}/replies", testSpec.getId(), newComment.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(replyRequest)))
+                    .andExpect(status().isCreated());
+
+            // 4. get comment list
+            mockMvc.perform(get(COMMENT_API_URL, testSpec.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.comments[*].content").value(org.hamcrest.Matchers.hasItem("통합테스트 댓글")));
+
+            // 5. update comment
+            CommentRequest updateRequest = new CommentRequest("수정된 통합테스트 댓글");
+
+            mockMvc.perform(patch(COMMENT_API_URL + "/{commentId}", testSpec.getId(), newComment.getId())
+                            .with(authentication(createAuthentication(testUser.getId())))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateRequest)))
+                    .andExpect(status().isOk());
+
+            // 6. delete comment
+            mockMvc.perform(delete(COMMENT_API_URL + "/{commentId}", testSpec.getId(), newComment.getId())
+                            .with(authentication(createAuthentication(testUser.getId()))))
+                    .andExpect(status().isOk());
+
+            Comment finalComment = commentRepository.findById(newComment.getId()).orElseThrow();
+            assertThat(finalComment.isDeleted()).isTrue();
+            assertThat(finalComment.getDeletedAt()).isNotNull();
+
+            // 7. get comment list (check comment deletion)
+            mockMvc.perform(get(COMMENT_API_URL, testSpec.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.comments[*].content")
+                            .value(org.hamcrest.Matchers.hasItem("삭제된 댓글입니다.")));
+        }
+    }
+
+    private Authentication createAuthentication(Long userId) {
+        AuthenticatedUserDto principal = new AuthenticatedUserDto(
+                userId, DEFAULT_USER_LOGIN_ID, DEFAULT_USER_NICKNAME, DEFAULT_USER_PROFILE_URL);
+        return new UsernamePasswordAuthenticationToken(principal, "", List.of());
+    }
 }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/RepositoryTestFixture.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/RepositoryTestFixture.java
@@ -1,8 +1,11 @@
 package kakaotech.bootcamp.respec.specranking.fixture;
 
 import kakaotech.bootcamp.respec.specranking.domain.social.comment.entity.Comment;
+import kakaotech.bootcamp.respec.specranking.domain.social.comment.repository.CommentRepository;
 import kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.Spec;
+import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRepository;
 import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
+import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
@@ -14,8 +17,8 @@ public class RepositoryTestFixture {
         User user = new User(
                 loginId,
                 "encoded_password_" + loginId,
-                nickname,
                 "https://example.com/profile/" + loginId + ".jpg",
+                nickname,
                 true
         );
         return entityManager.persistAndFlush(user);
@@ -23,6 +26,21 @@ public class RepositoryTestFixture {
 
     public static User createAndSaveDefaultUser(TestEntityManager entityManager) {
         return createAndSaveUser(entityManager, DEFAULT_USER_LOGIN_ID, DEFAULT_USER_NICKNAME);
+    }
+
+    public static User createAndSaveDefaultUserForIntegration(UserRepository userRepository) {
+        return createAndSaveUserForIntegration(userRepository, DEFAULT_USER_LOGIN_ID, DEFAULT_USER_NICKNAME);
+    }
+
+    public static User createAndSaveUserForIntegration(UserRepository userRepository, String loginId, String nickname) {
+        User user = new User(
+                loginId,
+                "encoded_password_" + loginId,
+                "https://example.com/profile/" + loginId + ".jpg",
+                nickname,
+                true
+        );
+        return userRepository.save(user);
     }
 
     public static User createAndSaveAnotherUser(TestEntityManager entityManager) {
@@ -48,6 +66,25 @@ public class RepositoryTestFixture {
         return createAndSaveSpec(entityManager, user, DEFAULT_ASSESSMENT);
     }
 
+    public static Spec createAndSaveDefaultSpecForIntegration(SpecRepository specRepository, User user) {
+        return createAndSaveSpecForIntegration(specRepository, user, DEFAULT_ASSESSMENT);
+    }
+
+    public static Spec createAndSaveSpecForIntegration(SpecRepository specRepository, User user, String assessment) {
+        Spec spec = new Spec(
+                user,
+                JobField.INTERNET_IT,
+                DEFAULT_EDUCATION_SCORE,
+                DEFAULT_WORK_EXPERIENCE_SCORE,
+                DEFAULT_ACTIVITY_NETWORKING_SCORE,
+                DEFAULT_CERTIFICATION_SCORE,
+                DEFAULT_ENGLISH_SKILL_SCORE,
+                DEFAULT_TOTAL_ANALYSIS_SCORE,
+                assessment
+        );
+        return specRepository.save(spec);
+    }
+
     public static Comment createAndSaveRootComment(TestEntityManager entityManager,
                                                    String content, User writer, Spec spec, int bundle) {
         Comment comment = new Comment(
@@ -61,6 +98,19 @@ public class RepositoryTestFixture {
         return entityManager.persistAndFlush(comment);
     }
 
+    public static Comment createAndSaveRootCommentForIntegration(CommentRepository commentRepository,
+                                                                 String content, User writer, Spec spec, int bundle) {
+        Comment comment = new Comment(
+                spec,
+                writer,
+                null,
+                content,
+                bundle,
+                ROOT_COMMENT_DEPTH
+        );
+        return commentRepository.save(comment);
+    }
+
     public static Comment createAndSaveReply(TestEntityManager entityManager, String content,
                                              User writer, Spec spec, Comment parentComment, int bundle) {
         Comment reply = new Comment(
@@ -72,6 +122,19 @@ public class RepositoryTestFixture {
                 REPLY_DEPTH
         );
         return entityManager.persistAndFlush(reply);
+    }
+
+    public static Comment createAndSaveReplyForIntegration(CommentRepository commentRepository, String content,
+                                             User writer, Spec spec, Comment parentComment, int bundle) {
+        Comment reply = new Comment(
+                spec,
+                writer,
+                parentComment,
+                content,
+                bundle,
+                REPLY_DEPTH
+        );
+        return commentRepository.save(reply);
     }
 
     private RepositoryTestFixture() { }

--- a/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/TestConstants.java
+++ b/src/test/java/kakaotech/bootcamp/respec/specranking/fixture/TestConstants.java
@@ -29,6 +29,7 @@ public class TestConstants {
     public static final Long DEFAULT_PARENT_COMMENT_ID = 3L;
     public static final Long REPLY_ID = 4L;
     public static final Long NON_EXISTENT_COMMENT_ID = 999L;
+    public static final Long NON_EXISTENT_PARENT_COMMENT_ID = 999L;
 
     public static final String DEFAULT_COMMENT_CONTENT = "테스트 댓글 내용";
     public static final String REPLY_CONTENT = "대댓글 내용";


### PR DESCRIPTION
## ☝️ 요약
Comment 도메인 integration 테스트코드 작성

<br/>

## ✏️ 상세 내용
- 통합테스트에서 다루는 케이스
  - 핵심 성공 시나리오
  - 주요 실패 시나리오
  - 전체 플로우 검증
  - 데이터베이스 상태 검증

- @Transactional 어노테이션 : 각 테스트 후 자동으로 롤백해줌
- 비즈니스 로직에서 많이 사용되는 `SecurityContextHolder` 관련 처리
  - `CommentIntegrationTest` 내에 `createAuthentication` 메소드를 생성하여 권한 부여

- `CommentIntegrationTest` : 13개 테스트 통과
  - 댓글 작성 통합 테스트
  - 대댓글 작성 통합 테스트
  - 댓글 수정 통합 테스트
  - 댓글 삭제 통합 테스트
  - 댓글 목록 조회 통합 테스트
  - 전체 플로우 통합 테스트

- Comment 도메인의 최종 테스트 커버리지
  - 클래스 기준 : 96%
  - 메서드 기준 : 97%
  - 줄 기준 : 99%
  - 브랜치 기준 : 91%
  - entity 관련 테스트코드를 작성하지 않아 커버리지가 90%대임

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
