### PR TITLE
feat: 분산환경을 위해 redis에 소셜로그인 요청 정보 저장

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/config/OAuth2RedisConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/config/OAuth2RedisConfig.java
@@ -1,0 +1,33 @@
+package kakaotech.bootcamp.respec.specranking.domain.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@Configuration
+public class OAuth2RedisConfig {
+
+    // OAuth2AuthorizationRequest 전용 RedisTemplate
+    // OAuth2AuthorizationRequest의 복잡한 객체 구조를 처리하기 위해 Jackson 아닌 JdkSerializationRedisSerializer 사용함
+
+    @Bean
+    public RedisTemplate<String, OAuth2AuthorizationRequest> oauth2AuthorizationRequestRedisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, OAuth2AuthorizationRequest> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        JdkSerializationRedisSerializer jdkSerializer = new JdkSerializationRedisSerializer();
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(jdkSerializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(jdkSerializer);
+
+        return template;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/config/SecurityConfig.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import kakaotech.bootcamp.respec.specranking.domain.auth.jwt.CustomSuccessHandler;
 import kakaotech.bootcamp.respec.specranking.domain.auth.jwt.JWTFilter;
 import kakaotech.bootcamp.respec.specranking.domain.auth.jwt.JWTUtil;
+import kakaotech.bootcamp.respec.specranking.domain.auth.repository.CustomAuthorizationRequestRepository;
 import kakaotech.bootcamp.respec.specranking.domain.auth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     @Value("${frontend.base-url}")
     private String frontendBaseUrl;
 
+    private final CustomAuthorizationRequestRepository authorizationRequestRepository;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
     private final JWTUtil jwtUtil;
@@ -75,6 +77,9 @@ public class SecurityConfig {
         // oauth2
         http
                 .oauth2Login((oauth2) -> oauth2
+                        .authorizationEndpoint(authorizationEndpoint ->
+                                authorizationEndpoint
+                                        .authorizationRequestRepository(authorizationRequestRepository))
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService))
                         .successHandler(customSuccessHandler)

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/repository/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/repository/CustomAuthorizationRequestRepository.java
@@ -1,0 +1,74 @@
+package kakaotech.bootcamp.respec.specranking.domain.auth.repository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class CustomAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private final RedisTemplate<String , OAuth2AuthorizationRequest> redisTemplate;
+
+    private static final String STATE_PARAMETER = "state";
+    private static final String OAUTH2_AUTHORIZATION_REQUEST_PREFIX = "oauth2:authorization:request:";
+    private static final Duration OAUTH2_AUTHORIZATION_REQUEST_EXPIRATION = Duration.ofSeconds(30);
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest httpServletRequest) {
+
+        String state = httpServletRequest.getParameter(STATE_PARAMETER);
+
+        if (state == null) {
+            log.warn("OAuth2AuthorizationRequest 로드 실패 - state 파라미터가 없습니다.");
+            return null;
+        }
+
+        String redisKey = OAUTH2_AUTHORIZATION_REQUEST_PREFIX + state;
+        OAuth2AuthorizationRequest authorizationRequest = redisTemplate.opsForValue().get(redisKey);;
+        log.info("OAuth2AuthorizationRequest 로드 완료 - state: {}, found: {}", state, authorizationRequest != null);
+
+        return authorizationRequest;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request, HttpServletResponse response) {
+
+        if (authorizationRequest == null) {
+            log.warn("OAuth2AuthorizationRequest 저장 실패 - authorizationRequest가 null입니다.");
+            return;
+        }
+
+        String state = authorizationRequest.getState();
+        String redisKey = OAUTH2_AUTHORIZATION_REQUEST_PREFIX + state;
+
+        redisTemplate.opsForValue().set(redisKey, authorizationRequest, OAUTH2_AUTHORIZATION_REQUEST_EXPIRATION);
+        log.info("OAuth2AuthorizationRequest 저장 완료 - state: {}", state);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+
+        String state = request.getParameter(STATE_PARAMETER);
+
+        if (state == null) {
+            log.warn("OAuth2AuthorizationRequest 삭제 실패 - state 파라미터가 없습니다.");
+            return null;
+        }
+
+        String redisKey = OAUTH2_AUTHORIZATION_REQUEST_PREFIX + state;
+        OAuth2AuthorizationRequest authorizationRequest = redisTemplate.opsForValue().get(redisKey);
+        log.info("OAuth2AuthorizationRequest 삭제 완료 - state: {}", state);
+
+        return authorizationRequest;
+    }
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/repository/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/repository/CustomAuthorizationRequestRepository.java
@@ -20,7 +20,7 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
 
     private static final String STATE_PARAMETER = "state";
     private static final String OAUTH2_AUTHORIZATION_REQUEST_PREFIX = "oauth2:authorization:request:";
-    private static final Duration OAUTH2_AUTHORIZATION_REQUEST_EXPIRATION = Duration.ofSeconds(30);
+    private static final Duration OAUTH2_AUTHORIZATION_REQUEST_EXPIRATION = Duration.ofSeconds(1);
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest httpServletRequest) {


### PR DESCRIPTION
## ☝️ 요약
분산환경을 위해 redis에 소셜로그인 요청 정보 저장

<br/>

## ✏️ 상세 내용
- 분산 환경으로 이전 후 로그인이 성공했다가 실패했다가 하는 문제 발생함
- 소셜로그인 요청 정보를 가진 서버에서 카카오 페이지를 갔다가 다른 서버로 돌아올 경우, 요청 정보를 가지고 있지 않아 문제가 발생하는 것으로 예상됨
- 어떤 서버에서든 요청을 받을 수 있도록 Redis에 소셜로그인 요청 정보를 1초 동안 저장하도록 구현함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로깅 정보를 남겼습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
