### PR TITLE
fix: 소셜로그인 요청 정보를 redis에 저장하는 시간을 5분으로 변경

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/repository/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/auth/repository/CustomAuthorizationRequestRepository.java
@@ -20,7 +20,7 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
 
     private static final String STATE_PARAMETER = "state";
     private static final String OAUTH2_AUTHORIZATION_REQUEST_PREFIX = "oauth2:authorization:request:";
-    private static final Duration OAUTH2_AUTHORIZATION_REQUEST_EXPIRATION = Duration.ofSeconds(1);
+    private static final Duration OAUTH2_AUTHORIZATION_REQUEST_EXPIRATION = Duration.ofMinutes(5);
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest httpServletRequest) {


### PR DESCRIPTION
## ☝️ 요약
소셜로그인 요청 정보를 redis에 저장하는 시간을 5분으로 변경

<br/>

## ✏️ 상세 내용
- 디버깅을 위해 redis 저장 시간을 임시로 1초에서 5분으로 늘림

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
