### PR TITLE
refactor: service 계층이 web 계층을 코드를 모르도록 분리

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chatparticipation/controller/ChatParticipationController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chatparticipation/controller/ChatParticipationController.java
@@ -1,6 +1,9 @@
 package kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.controller;
 
+import static kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.constant.ChatParticipationConstant.GET_CHAT_PARTICIPATIONS_SUCCESS_MESSAGE;
+
 import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.dto.response.ChatParticipationListResponse;
+import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.dto.response.ChatParticipationListResponse.ChatParticipationListData;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.service.ChatParticipationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +19,7 @@ public class ChatParticipationController {
 
     @GetMapping
     public ChatParticipationListResponse getChatParticipationList() {
-        return chatParticipationService.getChatParticipationList();
+        ChatParticipationListData chatParticipationList = chatParticipationService.getChatParticipationList();
+        return new ChatParticipationListResponse(true, GET_CHAT_PARTICIPATIONS_SUCCESS_MESSAGE, chatParticipationList);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chatparticipation/service/ChatParticipationService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chatparticipation/service/ChatParticipationService.java
@@ -2,7 +2,6 @@ package kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.serv
 
 import static kakaotech.bootcamp.respec.specranking.domain.auth.constant.AuthConstant.LOGIN_REQUIRED_MESSAGE;
 import static kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.constant.ChatParticipationConstant.CHAT_NOT_FOUND_MESSAGE;
-import static kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.constant.ChatParticipationConstant.GET_CHAT_PARTICIPATIONS_SUCCESS_MESSAGE;
 import static kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.constant.ChatParticipationConstant.PARTNER_NOT_FOUND_MESSAGE;
 import static kakaotech.bootcamp.respec.specranking.domain.user.constants.UserConstant.USER_NOT_FOUND_MESSAGE;
 
@@ -10,7 +9,6 @@ import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.auth.exception.LoginRequiredException;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chat.entity.Chat;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chat.repository.ChatRepository;
-import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.dto.response.ChatParticipationListResponse;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.dto.response.ChatParticipationListResponse.ChatParticipationListData;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.dto.response.ChatParticipationListResponse.ChatRoomDto;
 import kakaotech.bootcamp.respec.specranking.domain.chat.chatparticipation.entity.ChatParticipation;
@@ -34,7 +32,7 @@ public class ChatParticipationService {
     private final ChatRepository chatRepository;
     private final UserRepository userRepository;
 
-    public ChatParticipationListResponse getChatParticipationList() {
+    public ChatParticipationListData getChatParticipationList() {
         Long loginUserId = UserUtils.getCurrentUserId()
                 .orElseThrow(() -> new LoginRequiredException(LOGIN_REQUIRED_MESSAGE));
 
@@ -67,6 +65,6 @@ public class ChatParticipationService {
 
         ChatParticipationListData data = new ChatParticipationListData(chatroomDtos);
 
-        return new ChatParticipationListResponse(true, GET_CHAT_PARTICIPATIONS_SUCCESS_MESSAGE, data);
+        return data;
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chatparticipation/service/ChatParticipationService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chatparticipation/service/ChatParticipationService.java
@@ -63,8 +63,6 @@ public class ChatParticipationService {
                 })
                 .toList();
 
-        ChatParticipationListData data = new ChatParticipationListData(chatroomDtos);
-
-        return data;
+        return new ChatParticipationListData(chatroomDtos);
     }
 }

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/controller/NotificationController.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/controller/NotificationController.java
@@ -1,6 +1,9 @@
 package kakaotech.bootcamp.respec.specranking.domain.notification.controller;
 
+import static kakaotech.bootcamp.respec.specranking.domain.notification.constant.NotificationConstant.GET_NOTIFICATION_SUCCESS_MESSAGE;
+
 import kakaotech.bootcamp.respec.specranking.domain.notification.dto.response.NotificationStatusResponse;
+import kakaotech.bootcamp.respec.specranking.domain.notification.dto.response.NotificationStatusResponse.NotificationStatusData;
 import kakaotech.bootcamp.respec.specranking.domain.notification.service.NotificationService;
 import kakaotech.bootcamp.respec.specranking.global.dto.SimpleResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +21,8 @@ public class NotificationController {
 
     @GetMapping(params = "type=footer")
     public NotificationStatusResponse getNotificationStatus() {
-        return notificationService.getFooterNotificationStatus();
+        NotificationStatusData footerNotificationStatus = notificationService.getFooterNotificationStatus();
+        return new NotificationStatusResponse(true, GET_NOTIFICATION_SUCCESS_MESSAGE, footerNotificationStatus);
     }
 
     @DeleteMapping(params = "type=chat")

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/service/NotificationService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/notification/service/NotificationService.java
@@ -1,7 +1,6 @@
 package kakaotech.bootcamp.respec.specranking.domain.notification.service;
 
 import static kakaotech.bootcamp.respec.specranking.domain.auth.constant.AuthConstant.LOGIN_REQUIRED_MESSAGE;
-import static kakaotech.bootcamp.respec.specranking.domain.notification.constant.NotificationConstant.GET_NOTIFICATION_SUCCESS_MESSAGE;
 import static kakaotech.bootcamp.respec.specranking.domain.notification.constant.NotificationConstant.NOT_FOUND_CHAT_MESSAGE;
 import static kakaotech.bootcamp.respec.specranking.domain.notification.constant.NotificationConstant.NOT_FOUND_SOCIAL_MESSAGE;
 import static kakaotech.bootcamp.respec.specranking.domain.user.constants.UserConstant.USER_NOT_FOUND_MESSAGE_PREFIX;
@@ -10,7 +9,6 @@ import static kakaotech.bootcamp.respec.specranking.global.common.type.Notificat
 
 import java.util.List;
 import kakaotech.bootcamp.respec.specranking.domain.auth.exception.LoginRequiredException;
-import kakaotech.bootcamp.respec.specranking.domain.notification.dto.response.NotificationStatusResponse;
 import kakaotech.bootcamp.respec.specranking.domain.notification.dto.response.NotificationStatusResponse.NotificationStatusData;
 import kakaotech.bootcamp.respec.specranking.domain.notification.entity.Notification;
 import kakaotech.bootcamp.respec.specranking.domain.notification.exception.NotFoundChatNotificationException;
@@ -44,16 +42,14 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public NotificationStatusResponse getFooterNotificationStatus() {
+    public NotificationStatusData getFooterNotificationStatus() {
         Long userId = UserUtils.getCurrentUserId()
                 .orElseThrow(() -> new LoginRequiredException(LOGIN_REQUIRED_MESSAGE));
 
         boolean hasUnreadChat = notificationRepository.existsByUserIdAndTargetName(userId, CHAT);
         boolean hasUnreadComment = notificationRepository.existsByUserIdAndTargetName(userId, SOCIAL);
 
-        NotificationStatusData data = new NotificationStatusData(hasUnreadChat, hasUnreadComment);
-
-        return new NotificationStatusResponse(true, GET_NOTIFICATION_SUCCESS_MESSAGE, data);
+        return new NotificationStatusData(hasUnreadChat, hasUnreadComment);
     }
 
     public void deleteChatNotifications() {


### PR DESCRIPTION
## ☝️ 요약

service 계층이 web 계층을 코드를 모르도록 분리

## ✏️ 상세 내용

notification 과 chat 패키지에 대해서 service 계층이 web 계층 코드를 의존하고 있는 문제를 발견하였다.
이를 순수 data만 넘기도록 리팩토링한다.
controller에서 service에서 관련된 data를 받는다. web 계층에 종속된 로직은 controller에서만 담당한다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.