### PR TITLE
refactor: cursor 기반 페이지네이션 유틸 클래스 작성하여 역할 분리

### DIFF
--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/repository/ChatRepositoryImpl.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/chat/chat/repository/ChatRepositoryImpl.java
@@ -2,7 +2,7 @@ package kakaotech.bootcamp.respec.specranking.domain.chat.chat.repository;
 
 
 import static kakaotech.bootcamp.respec.specranking.domain.chat.chat.entity.QChat.chat;
-import static kakaotech.bootcamp.respec.specranking.global.common.util.CursorUtils.isFirstCursor;
+import static kakaotech.bootcamp.respec.specranking.global.common.util.cursor.CursorUtils.isFirstCursor;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/repository/SpecRepositoryImpl.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/repository/SpecRepositoryImpl.java
@@ -2,7 +2,7 @@ package kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository;
 
 import static kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.QSpec.spec;
 import static kakaotech.bootcamp.respec.specranking.domain.user.entity.QUser.user;
-import static kakaotech.bootcamp.respec.specranking.global.common.util.CursorUtils.isFirstCursor;
+import static kakaotech.bootcamp.respec.specranking.global.common.util.cursor.CursorUtils.isFirstCursor;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/domain/spec/spec/service/refresh/SpecRefreshQueryService.java
@@ -1,7 +1,7 @@
 package kakaotech.bootcamp.respec.specranking.domain.spec.spec.service.refresh;
 
 import static kakaotech.bootcamp.respec.specranking.domain.spec.spec.entity.QSpec.spec;
-import static kakaotech.bootcamp.respec.specranking.global.common.util.CursorUtils.encodeCursor;
+import static kakaotech.bootcamp.respec.specranking.global.common.util.cursor.CursorUtils.processCursorPagination;
 
 import com.querydsl.core.Tuple;
 import java.util.ArrayList;
@@ -19,6 +19,7 @@ import kakaotech.bootcamp.respec.specranking.domain.spec.spec.repository.SpecRep
 import kakaotech.bootcamp.respec.specranking.domain.user.entity.User;
 import kakaotech.bootcamp.respec.specranking.domain.user.repository.UserRepository;
 import kakaotech.bootcamp.respec.specranking.global.common.type.JobField;
+import kakaotech.bootcamp.respec.specranking.global.common.util.cursor.CursorPagination;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,15 +38,10 @@ public class SpecRefreshQueryService {
         long startTime = System.currentTimeMillis();
         List<Spec> specs = specRepository.findTopSpecsByJobFieldWithCursor(jobField, Long.MAX_VALUE, limit + 1);
 
-        boolean hasNext = specs.size() > limit;
-        if (hasNext) {
-            specs = specs.subList(0, limit);
-        }
-
-        String nextCursor = null;
-        if (hasNext) {
-            nextCursor = encodeCursor(specs.getLast().getId());
-        }
+        CursorPagination<Spec> cursorPagination = processCursorPagination(specs, limit, Spec::getId);
+        boolean hasNext = cursorPagination.hasNext();
+        specs = cursorPagination.items();
+        String nextCursor = cursorPagination.nextCursor();
 
         long countUsersHavingSpec = userRepository.countUsersHavingSpec();
 

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/util/cursor/CursorPagination.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/util/cursor/CursorPagination.java
@@ -1,0 +1,6 @@
+package kakaotech.bootcamp.respec.specranking.global.common.util.cursor;
+
+import java.util.List;
+
+public record CursorPagination<T>(List<T> items, boolean hasNext, String nextCursor) {
+}

--- a/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/util/cursor/CursorUtils.java
+++ b/src/main/java/kakaotech/bootcamp/respec/specranking/global/common/util/cursor/CursorUtils.java
@@ -1,6 +1,8 @@
-package kakaotech.bootcamp.respec.specranking.global.common.util;
+package kakaotech.bootcamp.respec.specranking.global.common.util.cursor;
 
 import java.util.Base64;
+import java.util.List;
+import java.util.function.Function;
 
 public class CursorUtils {
     public static String encodeCursor(Long id) {
@@ -15,6 +17,18 @@ public class CursorUtils {
         byte[] decodedBytes = Base64.getDecoder().decode(cursor);
         String decodedString = new String(decodedBytes);
         return Long.parseLong(decodedString);
+    }
+
+    public static <T> CursorPagination<T> processCursorPagination(List<T> items, int limit,
+                                                                  Function<T, Long> idExtractor) {
+        boolean hasNext = items.size() > limit;
+        if (hasNext) {
+            items = items.subList(0, limit);
+        }
+
+        String nextCursor = hasNext ? encodeCursor(idExtractor.apply(items.getLast())) : null;
+
+        return new CursorPagination<>(items, hasNext, nextCursor);
     }
 
     public static boolean isFirstCursor(Long cursorId) {


### PR DESCRIPTION
## ☝️ 요약

cursor 기반 페이지네이션 유틸 클래스 작성하여 역할 분리

## ✏️ 상세 내용

chat과 spec에서 커서 기반 페이지네이션을 사용한다.

이를 util 클래스로 작성하여 페이지네이션 정보를 가져오는 역할을 분리한다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.